### PR TITLE
Add preprocessors argument to format_output().

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version TBD
 (released on TBD)
 
 * Make vertical table separator more customizable.
+* Add ability to pass additional preprocessors when formatting output.
 
 
 Version 0.1.0

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -37,3 +37,9 @@ def intlen(n):
 def filter_dict_by_key(d, keys):
     """Filter the dict *d* to remove keys not in *keys*."""
     return {k: v for k, v in d.items() if k in keys}
+
+
+def unique_items(seq):
+    """Return the unique items from iterable *seq* (in order)."""
+    seen = set()
+    return [x for x in seq if not (x in seen or seen.add(x))]

--- a/tests/tabular_output/test_output_formatter.py
+++ b/tests/tabular_output/test_output_formatter.py
@@ -24,3 +24,28 @@ def test_tabular_output_formatter():
 
     assert expected == TabularOutputFormatter().format_output(
         data, headers, format_name='ascii')
+
+
+def test_additional_preprocessors():
+    """Test that additional preprocessors are run."""
+    def hello_world(data, headers, **_):
+        for row in data:
+            for i, value in enumerate(row):
+                if value == 'hello':
+                    row[i] = "{}, world".format(value)
+        return data, headers
+
+    data = [['foo', None], ['hello!', 'hello']]
+    headers = 'ab'
+
+    expected = dedent('''\
+        +--------+--------------+
+        | a      | b            |
+        +--------+--------------+
+        | foo    | hello        |
+        | hello! | hello, world |
+        +--------+--------------+''')
+
+    assert expected == TabularOutputFormatter().format_output(
+        data, headers, format_name='ascii', preprocessors=(hello_world,),
+        missing_value='hello')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This adds a `preprocessors` argument to `TabularOutputFormatter.format_output()`. This is used to pass additional preprocessors that should be run when formatting the output.

Additional preprocessors are run before the default preprocessors for a formatter. Preprocessors are also de-duped so that each preprocessor is only run once.

This can be used to always run the `missing_value` preprocessor for pgcli/mycli so that missing values that contain color codes will not affect the alignment in tabulate: https://github.com/dbcli/pgcli/commit/4f7add55421574ebcba3ceb5dce17c98a377a9df


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
