### PR TITLE
Add styled output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - python: 3.6
       env: TOXENV=py36
     - python: 3.6
+      env: TOXENV=noextras
+    - python: 3.6
       env: TOXENV=docs
     - python: 3.6
       env: TOXENV=packaging

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Version TBD
 * Don't install tests.tabular_output.
 * Add .gitignore
 * Coverage for tox tests.
+* Style formatted output with Pygments (optional).
 
 
 Version 0.1.0

--- a/cli_helpers/compat.py
+++ b/cli_helpers/compat.py
@@ -16,3 +16,11 @@ else:
     binary_type = bytes
 
     from io import StringIO
+
+
+HAS_PYGMENTS = True
+try:
+    from pygments.formatters.terminal256 import Terminal256Formatter
+except ImportError:
+    HAS_PYGMENTS = False
+    Terminal256Formatter = None

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -3,7 +3,7 @@
 
 from cli_helpers.packages import tabulate
 from cli_helpers.utils import filter_dict_by_key
-from .preprocessors import bytes_to_string, align_decimals
+from .preprocessors import convert_to_string, align_decimals, style_output
 
 supported_markup_formats = ('mediawiki', 'html', 'latex', 'latex_booktabs',
                             'textile', 'moinmoin', 'jira')
@@ -11,7 +11,7 @@ supported_table_formats = ('plain', 'simple', 'grid', 'fancy_grid', 'pipe',
                            'orgtbl', 'psql', 'rst')
 supported_formats = supported_markup_formats + supported_table_formats
 
-preprocessors = (bytes_to_string, align_decimals)
+preprocessors = (align_decimals, convert_to_string, style_output)
 
 
 def adapter(data, headers, table_format=None, missing_value='',

--- a/cli_helpers/tabular_output/terminaltables_adapter.py
+++ b/cli_helpers/tabular_output/terminaltables_adapter.py
@@ -4,11 +4,12 @@
 import terminaltables
 
 from cli_helpers.utils import filter_dict_by_key
-from .preprocessors import (bytes_to_string, align_decimals,
-                            override_missing_value)
+from .preprocessors import (convert_to_string, align_decimals,
+                            override_missing_value, style_output)
 
 supported_formats = ('ascii', 'double', 'github')
-preprocessors = (bytes_to_string, override_missing_value, align_decimals)
+preprocessors = (override_missing_value, align_decimals, convert_to_string,
+                 style_output)
 
 
 def adapter(data, headers, table_format=None, **kwargs):

--- a/cli_helpers/tabular_output/vertical_table_adapter.py
+++ b/cli_helpers/tabular_output/vertical_table_adapter.py
@@ -4,10 +4,11 @@
 from __future__ import unicode_literals
 
 from cli_helpers.utils import filter_dict_by_key
-from .preprocessors import convert_to_string, override_missing_value
+from .preprocessors import (convert_to_string, override_missing_value,
+                            style_output)
 
 supported_formats = ('vertical', )
-preprocessors = (override_missing_value, convert_to_string)
+preprocessors = (override_missing_value, convert_to_string, style_output)
 
 
 def _get_separator(num, sep_title, sep_character, sep_length):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,6 @@ You can get the library directly from `PyPI <https://pypi.org/>`_::
 
     $ pip install cli_helpers
 
-
 User Guide
 ----------
 .. toctree::

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
     install_requires=[
         'terminaltables >= 3.0.0'
     ],
+    extras_require={
+        'styles':  ['Pygments >= 1.6'],
+    },
     entry_points={
         'distutils.commands': [
             'lint = tasks:lint',

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -101,7 +101,8 @@ def test_style_output_no_styles():
     assert (data, headers) == style_output(data, headers)
 
 
-@pytest.mark.skipif(HAS_PYGMENTS, reason='requires no Pygments library')
+@pytest.mark.skipif(HAS_PYGMENTS,
+                    reason='requires the Pygments library be missing')
 def test_style_output_no_pygments():
     """Test that *style_output()* does not try to style without Pygments."""
     headers = ['h1', 'h2']

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -132,3 +132,31 @@ def test_style_output():
 
     assert (expected_data, expected_headers) == style_output(data, headers,
                                                              style=CliStyle)
+
+
+@pytest.mark.skipif(not HAS_PYGMENTS, reason='requires the Pygments library')
+def test_style_output_custom_tokens():
+    """Test that *style_output()* styles output with custom token names."""
+
+    class CliStyle(Style):
+        default_style = ""
+        styles = {
+            Token.Results.Headers: 'bold #ansired',
+            Token.Results.OddRows: 'bg:#eee #111',
+            Token.Results.EvenRows: '#0f0'
+        }
+    headers = ['h1', 'h2']
+    data = [['1', '2'], ['a', 'b']]
+
+    expected_headers = ['\x1b[31;01mh1\x1b[39;00m', '\x1b[31;01mh2\x1b[39;00m']
+    expected_data = [['\x1b[38;5;233;48;5;7m1\x1b[39;49m',
+                      '\x1b[38;5;233;48;5;7m2\x1b[39;49m'],
+                     ['\x1b[38;5;10ma\x1b[39m', '\x1b[38;5;10mb\x1b[39m']]
+
+    output = style_output(
+        data, headers, style=CliStyle,
+        header_token='Token.Results.Headers',
+        odd_row_token='Token.Results.OddRows',
+        even_row_token='Token.Results.EvenRows')
+
+    assert (expected_data, expected_headers) == output

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -4,11 +4,16 @@
 from __future__ import unicode_literals
 from decimal import Decimal
 
-from cli_helpers.tabular_output.preprocessors import (align_decimals,
-                                                      bytes_to_string,
-                                                      convert_to_string,
-                                                      quote_whitespaces,
-                                                      override_missing_value)
+import pytest
+
+from cli_helpers.compat import HAS_PYGMENTS
+from cli_helpers.tabular_output.preprocessors import (
+    align_decimals, bytes_to_string, convert_to_string, quote_whitespaces,
+    override_missing_value, style_output)
+
+if HAS_PYGMENTS:
+    from pygments.style import Style
+    from pygments.token import Token
 
 
 def test_convert_to_string():
@@ -85,3 +90,44 @@ def test_quote_whitespaces_non_spaces():
                 ['h1', 'h2'])
 
     assert expected == quote_whitespaces(data, headers)
+
+
+@pytest.mark.skipif(not HAS_PYGMENTS, reason='requires the Pygments library')
+def test_style_output_no_styles():
+    """Test that *style_output()* does not style without styles."""
+    headers = ['h1', 'h2']
+    data = [['1', '2'], ['a', 'b']]
+
+    assert (data, headers) == style_output(data, headers)
+
+
+@pytest.mark.skipif(HAS_PYGMENTS, reason='requires no Pygments library')
+def test_style_output_no_pygments():
+    """Test that *style_output()* does not try to style without Pygments."""
+    headers = ['h1', 'h2']
+    data = [['1', '2'], ['a', 'b']]
+
+    assert (data, headers) == style_output(data, headers)
+
+
+@pytest.mark.skipif(not HAS_PYGMENTS, reason='requires the Pygments library')
+def test_style_output():
+    """Test that *style_output()* styles output."""
+
+    class CliStyle(Style):
+        default_style = ""
+        styles = {
+            Token.Output.Header: 'bold #ansired',
+            Token.Output.OddRow: 'bg:#eee #111',
+            Token.Output.EvenRow: '#0f0'
+        }
+    headers = ['h1', 'h2']
+    data = [['1', '2'], ['a', 'b']]
+
+    expected_headers = ['\x1b[31;01mh1\x1b[39;00m', '\x1b[31;01mh2\x1b[39;00m']
+    expected_data = [['\x1b[38;5;233;48;5;7m1\x1b[39;49m',
+                      '\x1b[38;5;233;48;5;7m2\x1b[39;49m'],
+                     ['\x1b[38;5;10ma\x1b[39m', '\x1b[38;5;10mb\x1b[39m']]
+
+    assert (expected_data, expected_headers) == style_output(data, headers,
+                                                             style=CliStyle)

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,9 @@ deps = -r{toxinidir}/requirements-dev.txt
 usedevelop = True
 
 [testenv:noextras]
-install_command =
-   pip install {opts} {packages}
-   pip uninstall Pygments
+commands =
+    pip uninstall -y Pygments
+    {[testenv]commands}
 
 [testenv:docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init, py27, py33, py34, py35, py36, docs, packaging, cov-report
+envlist = cov-init, py27, py33, py34, py35, py36, noextras, docs, packaging, cov-report
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_* CODECOV
@@ -14,6 +14,11 @@ commands =
     bash -c 'if [ -n "$CODECOV" ]; then {envbindir}/coverage xml && {envbindir}/codecov; fi'
 deps = -r{toxinidir}/requirements-dev.txt
 usedevelop = True
+
+[testenv:noextras]
+install_command =
+   pip install {opts} {packages}
+   pip uninstall Pygments
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This adds styled output (headers, odd row, and even row) powered by Pygments. This provides foreground colors, background colors, and bold/underline/italics.

This is an optional CLI Helpers feature that is enabled if Pygments is installed. Since this isn't required to make the essential pieces of CLI Helpers work, it's optional. I think that's a good policy to take since CLI Helpers is designed to be used by other applications outside of dbcli. It can be required downstream (e.g. mycli and pgcli) by using the setuptools extras syntax. For example, in mycli we might change the CLI Helpers dependency from `cli_helpers` to `cli_helpers[styles]`.

It requires a Pygments style class to be passed in that will respond to the desired tokens (defaults to `Token.Output.Header`, `Token.Output.OddRow`, and `Token.Output.EvenRow`).

In order for this to work, I had to convert all the output to string (after we align decimal places).

Here is the rendered documentation for this preprocessor: http://cli-helpers.readthedocs.io/en/feature-styles/api.html#cli_helpers.tabular_output.preprocessors.style_output


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
