### PR TITLE
Use override_missing_value for tabulate.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Version TBD
 * Don't install tests.tabular_output.
 * Add .gitignore
 * Coverage for tox tests.
+* Fix issue where tabulate can't handle ANSI escape codes in default values.
 
 
 Version 0.1.0

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -3,7 +3,8 @@
 
 from cli_helpers.packages import tabulate
 from cli_helpers.utils import filter_dict_by_key
-from .preprocessors import bytes_to_string, align_decimals
+from .preprocessors import (bytes_to_string, align_decimals,
+                            override_missing_value)
 
 supported_markup_formats = ('mediawiki', 'html', 'latex', 'latex_booktabs',
                             'textile', 'moinmoin', 'jira')
@@ -11,7 +12,7 @@ supported_table_formats = ('plain', 'simple', 'grid', 'fancy_grid', 'pipe',
                            'orgtbl', 'psql', 'rst')
 supported_formats = supported_markup_formats + supported_table_formats
 
-preprocessors = (bytes_to_string, align_decimals)
+preprocessors = (bytes_to_string, override_missing_value, align_decimals)
 
 
 def adapter(data, headers, table_format=None, missing_value='',

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -15,12 +15,11 @@ supported_formats = supported_markup_formats + supported_table_formats
 preprocessors = (bytes_to_string, override_missing_value, align_decimals)
 
 
-def adapter(data, headers, table_format=None, missing_value='',
-            preserve_whitespace=False, **kwargs):
+def adapter(data, headers, table_format=None, preserve_whitespace=False,
+            **kwargs):
     """Wrap tabulate inside a function for TabularOutputFormatter."""
-    keys = ('floatfmt', 'numalign', 'stralign', 'missingval', 'showindex',
-            'disable_numparse')
-    tkwargs = {'tablefmt': table_format, 'missingval': missing_value}
+    keys = ('floatfmt', 'numalign', 'stralign', 'showindex', 'disable_numparse')
+    tkwargs = {'tablefmt': table_format}
     tkwargs.update(filter_dict_by_key(kwargs, keys))
 
     if table_format in supported_markup_formats:

--- a/tests/tabular_output/test_output_formatter.py
+++ b/tests/tabular_output/test_output_formatter.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 import pytest
 
 from cli_helpers.tabular_output import format_output, TabularOutputFormatter
+from tests.utils import strip_ansi
 
 
 def test_tabular_output_formatter():
@@ -91,3 +92,17 @@ def test_unsupported_format():
 
     with pytest.raises(ValueError):
         formatter.format_output((), (), format_name='foobar')
+
+
+def test_tabulate_ansi_escape_in_default_value():
+    """Test that ANSI escape codes work with tabulate."""
+
+    data = [['1', None], ['2', 'Sam'],
+            ['3', 'Joe']]
+    headers = ['id', 'name']
+
+    styled = format_output(data, headers, format_name='psql',
+                           missing_value='\x1b[38;5;10mNULL\x1b[39m')
+    unstyled = format_output(data, headers, format_name='psql',
+                             missing_value='NULL')
+    assert strip_ansi(styled) == unstyled

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for CLI Helpers' tests."""
+
+import re
+
+_ansi_re = re.compile('\033\[((?:\d|;)*)([a-zA-Z])')
+
+
+def strip_ansi(value):
+    """Strip the ANSI escape sequences from a string."""
+    return _ansi_re.sub('', value)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Tabulate doesn't do well when the default value has ANSI escape codes in it (e.g. https://github.com/dbcli/pgcli/commit/4f7add55421574ebcba3ceb5dce17c98a377a9df). This is needed to match pgcli's behavior.

This uses the `override_missing_value` preprocessor to get around that. Tabulate can handle ANSI escape codes in the data rows themselves.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
