### PR TITLE
Add macOS tests via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,29 @@
 sudo: false
 language: python
 cache: pip
-install: pip install tox
+install: ./.travis/install.sh
 script: tox
 
 matrix:
   include:
-    - python: 2.7
+    - os: linux
+      python: 2.7
       env: TOXENV=py27
-    - python: 3.4
+    - os: linux
+      python: 3.4
       env: TOXENV=py34
-    - python: 3.5
+    - os: linux
+      python: 3.5
       env: TOXENV=py35
-    - python: 3.6
+    - os: linux
+      python: 3.6
       env: TOXENV=py36
-    - python: 3.6
+    - os: linux
+      python: 3.6
       env: TOXENV=noextras
-    - python: 3.6
+    - os: linux
+      python: 3.6
       env: TOXENV=docs
-    - python: 3.6
+    - os: linux
+      python: 3.6
       env: TOXENV=packaging

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,9 @@ matrix:
     - os: linux
       python: 3.6
       env: TOXENV=packaging
+    - os: osx
+      language: generic
+      env: TOXENV=py27
+    - os: osx
+      language: generic
+      env: TOXENV=py36

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 language: python
 cache: pip
 install: ./.travis/install.sh
-script: tox
+script:
+  - source ~/.venv/bin/activate
+  - tox
 
 matrix:
   include:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -x
+set -ex
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     sw_vers

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    sw_vers
+
+    git clone --depth 1 https://github.com/pyenv/pyenv ~/.pyenv
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
+
+    case "${TOXENV}" in
+        py27)
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py --user
+            ;;
+        py36)
+            pyenv install 3.6.1
+            pyenv global 3.6.1
+            ;;
+    esac
+    pyenv rehash
+    python -m pip install --user virtualenv
+fi
+
+python -m virtualenv ~/.venv
+source ~/.venv/bin/activate
+pip install tox

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -6,8 +6,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     sw_vers
 
     git clone --depth 1 https://github.com/pyenv/pyenv ~/.pyenv
-    PYENV_ROOT="$HOME/.pyenv"
-    PATH="$PYENV_ROOT/bin:$PATH"
+    export PYENV_ROOT="$HOME/.pyenv"
+    export PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
 
     case "${TOXENV}" in

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -25,4 +25,7 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     python -m pip install --user virtualenv
 fi
 
+pip install virtualenv
+python -m virtualenv ~/.venv
+source ~/.venv/bin/activate
 pip install tox

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -22,7 +22,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             ;;
     esac
     pyenv rehash
-    python -m pip install --user virtualenv
 fi
 
 pip install virtualenv

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -25,6 +25,4 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     python -m pip install --user virtualenv
 fi
 
-python -m virtualenv ~/.venv
-source ~/.venv/bin/activate
 pip install tox

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version TBD
+-----------
+Run tests on macOS via Travis.
+
+
 Version 0.2.0
 -------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ ignore =
     appveyor.yml
     .travis.yml
     .github*
+    .travis*
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This adds macOS tests to the Travis config. The upcoming config pull request has mac-specific code that will be useful to test in Travis (i.e. finding Mac-appropriate config file locations when the client app explicitly does not want to follow the XDG spec).

Travis does not have built-in support for testing Python apps on macOS, so this uses a [cryptography-influenced](https://github.com/pyca/cryptography/blob/master/.travis/install.sh) `.travis/install.sh` bash script to set up Python on macOS.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
