### PR TITLE
Fix unicode problems

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@ Changelog
 
 Version TBD
 -----------
-Run tests on macOS via Travis.
+* Run tests on macOS via Travis.
+* Fix unicode issues on Python 2 (csv and styling output).
 
 
 Version 0.2.0

--- a/cli_helpers/compat.py
+++ b/cli_helpers/compat.py
@@ -13,14 +13,14 @@ if PY2:
     long_type = long
     int_types = (int, long)
 
-    from cStringIO import StringIO
+    from backports import csv
 else:
     text_type = str
     binary_type = bytes
     long_type = int
     int_types = (int,)
 
-    from io import StringIO
+    import csv
 
 
 HAS_PYGMENTS = True

--- a/cli_helpers/tabular_output/delimited_output_adapter.py
+++ b/cli_helpers/tabular_output/delimited_output_adapter.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """A delimited data output adapter (e.g. CSV, TSV)."""
 
+from __future__ import unicode_literals
 import contextlib
-import csv
+from io import StringIO
 
-from cli_helpers.compat import StringIO
+from cli_helpers.compat import csv
 from cli_helpers.utils import filter_dict_by_key
 from .preprocessors import bytes_to_string, override_missing_value
 

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """These preprocessor functions are used to process data prior to output."""
 
+from io import StringIO
 import string
 
 from cli_helpers import utils
-from cli_helpers.compat import (StringIO, text_type, int_types, float_types,
+from cli_helpers.compat import (text_type, int_types, float_types,
                                 HAS_PYGMENTS, Terminal256Formatter)
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
     description='Helpers for building command-line apps',
     long_description=readme,
     install_requires=[
-        'terminaltables >= 3.0.0'
+        'terminaltables >= 3.0.0',
+        'backports.csv >= 1.0.0'
     ],
     extras_require={
         'styles':  ['Pygments >= 1.6'],

--- a/tests/tabular_output/test_delimited_output_adapter.py
+++ b/tests/tabular_output/test_delimited_output_adapter.py
@@ -12,7 +12,7 @@ from cli_helpers.tabular_output import delimited_output_adapter
 def test_csv_wrapper():
     """Test the delimited output adapter."""
     # Test comma-delimited output.
-    data = [['abc', 1], ['d', 456]]
+    data = [['abc', '1'], ['d', '456']]
     headers = ['letters', 'number']
     output = delimited_output_adapter.adapter(data, headers)
     assert output == dedent('''\
@@ -21,7 +21,7 @@ def test_csv_wrapper():
         d,456\r\n''')
 
     # Test tab-delimited output.
-    data = [['abc', 1], ['d', 456]]
+    data = [['abc', '1'], ['d', '456']]
     headers = ['letters', 'number']
     output = delimited_output_adapter.adapter(
         data, headers, table_format='tsv')
@@ -33,3 +33,15 @@ def test_csv_wrapper():
     with pytest.raises(ValueError):
         output = delimited_output_adapter.adapter(
             data, headers, table_format='foobar')
+
+
+def test_unicode_with_csv():
+    """Test that the csv wrapper can handle non-ascii characters."""
+    data = [['观音', '1'], ['Ποσειδῶν', '456']]
+    headers = ['letters', 'number']
+    output = delimited_output_adapter.adapter(data, headers)
+    assert output == dedent('''\
+        letters,number\r\n\
+        观音,1\r\n\
+        Ποσειδῶν,456\r\n''')
+

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -135,12 +135,12 @@ def test_style_output():
             Token.Output.EvenRow: '#0f0'
         }
     headers = ['h1', 'h2']
-    data = [['1', '2'], ['a', 'b']]
+    data = [['观音', '2'], ['Ποσειδῶν', 'b']]
 
     expected_headers = ['\x1b[31;01mh1\x1b[39;00m', '\x1b[31;01mh2\x1b[39;00m']
-    expected_data = [['\x1b[38;5;233;48;5;7m1\x1b[39;49m',
+    expected_data = [['\x1b[38;5;233;48;5;7m观音\x1b[39;49m',
                       '\x1b[38;5;233;48;5;7m2\x1b[39;49m'],
-                     ['\x1b[38;5;10ma\x1b[39m', '\x1b[38;5;10mb\x1b[39m']]
+                     ['\x1b[38;5;10mΠοσειδῶν\x1b[39m', '\x1b[38;5;10mb\x1b[39m']]
 
     assert (expected_data, expected_headers) == style_output(data, headers,
                                                              style=CliStyle)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This fixes two unicode issues in CLI Helpers.
1. On Python 2, we now use `io.StringIO` instead of `StringIO.StringIO`. The `io` package apparently has the same behavior as Python 3.
2. We use [`backports.csv`](https://github.com/ryanhiebert/backports.csv) for Python 2's csv writing since it has the same API as Python 3's `csv` module.

Also, adds unicode tests for styling output and writing to CSV.

This addresses #18.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
