### PR TITLE
Use itertools to get column types.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version TBD
+-------------
+
+(released on TBD)
+
+* Fix IndexError from being raised with uneven rows.
+
 Version 0.2.1
 -------------
 

--- a/cli_helpers/compat.py
+++ b/cli_helpers/compat.py
@@ -14,6 +14,7 @@ if PY2:
     int_types = (int, long)
 
     from backports import csv
+    from itertools import izip_longest as zip_longest
 else:
     text_type = str
     binary_type = bytes
@@ -21,6 +22,7 @@ else:
     int_types = (int,)
 
     import csv
+    from itertools import zip_longest
 
 
 HAS_PYGMENTS = True

--- a/cli_helpers/tabular_output/output_formatter.py
+++ b/cli_helpers/tabular_output/output_formatter.py
@@ -4,7 +4,8 @@
 from __future__ import unicode_literals
 from collections import namedtuple
 
-from cli_helpers.compat import text_type, binary_type, int_types, float_types
+from cli_helpers.compat import (text_type, binary_type, int_types, float_types,
+                                zip_longest)
 from cli_helpers.utils import unique_items
 from . import (delimited_output_adapter, vertical_table_adapter,
                tabulate_adapter, terminaltables_adapter)
@@ -147,7 +148,7 @@ class TabularOutputFormatter(object):
 
     def _get_column_types(self, data):
         """Get a list of the data types for each column in *data*."""
-        columns = list(zip(*data))
+        columns = list(zip_longest(*data))
         return [self._get_column_type(column) for column in columns]
 
     def _get_column_type(self, column):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

If the number of columns in the data is uneven, CLI Helpers raises an `IndexError`. This fixes that by using `itertools.zip_longest` when calculating column types.

This fixes https://github.com/dbcli/pgcli/issues/749.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
