### PR TITLE
Fix python2 styling with newlines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version TBD
+-------------
+
+(released on TBD)
+
+* Fix unicode error on Python 2 with newlines in output row.
+
+
 Version 0.2.2
 -------------
 

--- a/cli_helpers/compat.py
+++ b/cli_helpers/compat.py
@@ -14,6 +14,8 @@ if PY2:
     int_types = (int, long)
 
     from backports import csv
+
+    from StringIO import StringIO
     from itertools import izip_longest as zip_longest
 else:
     text_type = str
@@ -22,6 +24,7 @@ else:
     int_types = (int,)
 
     import csv
+    from io import StringIO
     from itertools import zip_longest
 
 

--- a/cli_helpers/tabular_output/delimited_output_adapter.py
+++ b/cli_helpers/tabular_output/delimited_output_adapter.py
@@ -3,9 +3,8 @@
 
 from __future__ import unicode_literals
 import contextlib
-from io import StringIO
 
-from cli_helpers.compat import csv
+from cli_helpers.compat import csv, StringIO
 from cli_helpers.utils import filter_dict_by_key
 from .preprocessors import bytes_to_string, override_missing_value
 

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 """These preprocessor functions are used to process data prior to output."""
 
-from io import StringIO
 import string
 
 from cli_helpers import utils
 from cli_helpers.compat import (text_type, int_types, float_types,
-                                HAS_PYGMENTS, Terminal256Formatter)
+                                HAS_PYGMENTS, Terminal256Formatter, StringIO)
 
 
 def convert_to_string(data, headers, **_):

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -147,6 +147,30 @@ def test_style_output():
 
 
 @pytest.mark.skipif(not HAS_PYGMENTS, reason='requires the Pygments library')
+def test_style_output_with_newlines():
+    """Test that *style_output()* styles output with newlines in it."""
+
+    class CliStyle(Style):
+        default_style = ""
+        styles = {
+            Token.Output.Header: 'bold #ansired',
+            Token.Output.OddRow: 'bg:#eee #111',
+            Token.Output.EvenRow: '#0f0'
+        }
+    headers = ['h1', 'h2']
+    data = [['Line1\nLine2', '2']]
+
+    expected_headers = ['\x1b[31;01mh1\x1b[39;00m', '\x1b[31;01mh2\x1b[39;00m']
+    expected_data = [
+        ['\x1b[38;5;233;48;5;7mLine1\x1b[39;49m\n\x1b[38;5;233;48;5;7m'
+         'Line2\x1b[39;49m',
+         '\x1b[38;5;233;48;5;7m2\x1b[39;49m']]
+
+    assert (expected_data, expected_headers) == style_output(data, headers,
+                                                             style=CliStyle)
+
+
+@pytest.mark.skipif(not HAS_PYGMENTS, reason='requires the Pygments library')
 def test_style_output_custom_tokens():
     """Test that *style_output()* styles output with custom token names."""
 

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -158,13 +158,13 @@ def test_style_output_with_newlines():
             Token.Output.EvenRow: '#0f0'
         }
     headers = ['h1', 'h2']
-    data = [['Line1\nLine2', '2']]
+    data = [['观音\nLine2', 'Ποσειδῶν']]
 
     expected_headers = ['\x1b[31;01mh1\x1b[39;00m', '\x1b[31;01mh2\x1b[39;00m']
     expected_data = [
-        ['\x1b[38;5;233;48;5;7mLine1\x1b[39;49m\n\x1b[38;5;233;48;5;7m'
+        ['\x1b[38;5;233;48;5;7m观音\x1b[39;49m\n\x1b[38;5;233;48;5;7m'
          'Line2\x1b[39;49m',
-         '\x1b[38;5;233;48;5;7m2\x1b[39;49m']]
+         '\x1b[38;5;233;48;5;7mΠοσειδῶν\x1b[39;49m']]
 
     assert (expected_data, expected_headers) == style_output(data, headers,
                                                              style=CliStyle)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Python 2 has three versions of `StringIO`:
1. `cStringIO.StringIO` (bytes-only)
2. `io.StringIO` (unicode-only)
3. `StringIO.StringIO` (unicode and 8-bit strings).

We've already tried using the first two, here's to the third 🍺 .

On Python 2, if a row has a newline in it, Pygments does some extra handling for styled output. It outputs a newline (in bytes), which `io.StringIO` cannot handle.

This addresses https://github.com/dbcli/mycli/issues/479.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
