### PR TITLE
Use backports.csv only for py2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,7 +14,7 @@ Contributors
 
 This project receives help from these awesome contributors:
 
-- None yet. Why not be the first?
+- Terje Røsten
 
 
 Thanks

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,11 @@ Changelog
 TBD
 ---
 
+(to be released)
+
 * Output as generator
+* Use backports.csv only for py2
+
 
 Version 0.2.3
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [coverage:run]
 source = cli_helpers
 omit = cli_helpers/packages/*.py

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 import ast
 from io import open
 import re
+import sys
 
 from setuptools import find_packages, setup
 
@@ -22,6 +23,11 @@ def open_file(filename):
 
 readme = open_file('README.rst')
 
+if sys.version_info[0] == 2:
+    py2_reqs = [ 'backports.csv >= 1.0.0', ]
+else:
+    py2_reqs = []
+
 setup(
     name='cli_helpers',
     author='dbcli',
@@ -34,8 +40,7 @@ setup(
     long_description=readme,
     install_requires=[
         'terminaltables >= 3.0.0',
-        'backports.csv >= 1.0.0'
-    ],
+    ] + py2_reqs,
     extras_require={
         'styles':  ['Pygments >= 1.6'],
     },


### PR DESCRIPTION
## Description

Fixed by Terje Røsten
https://bugzilla.redhat.com/attachment.cgi?id=1314388&action=diff

The rationale behind not installing backports.csv for Python 3 is that it isn't available for Fedora.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
