### PR TITLE
Do not test travis macOS py27.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,4 @@ matrix:
       env: TOXENV=packaging
     - os: osx
       language: generic
-      env: TOXENV=py27
-    - os: osx
-      language: generic
       env: TOXENV=py36


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Travis CI does not appear to support tests on macOS using Python 2.7 any longer. The CLI Helpers tests have been failing for quite awhile because of this. This fixes the failing test suite by removing that environment from the travis config file.
