### PR TITLE
Add color in table

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Contributors
 This project receives help from these awesome contributors:
 
 - Terje Røsten
+- Frederic Aoustin
 
 
 Thanks

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -7,6 +7,9 @@ from .preprocessors import (convert_to_string, override_missing_value,
 
 import tabulate
 
+import click
+import click.termui
+
 supported_markup_formats = ('mediawiki', 'html', 'latex', 'latex_booktabs',
                             'textile', 'moinmoin', 'jira')
 supported_table_formats = ('plain', 'simple', 'grid', 'fancy_grid', 'pipe',
@@ -15,6 +18,22 @@ supported_formats = supported_markup_formats + supported_table_formats
 
 preprocessors = (override_missing_value, convert_to_string, style_output)
 
+def addColorInElt(elt, col):
+    if not elt:
+        return elt
+    if elt.__class__ == tabulate.Line:
+        return tabulate.Line(*(click.style(val,fg=col) for val in elt))
+    if elt.__class__ == tabulate.DataRow:
+        return tabulate.DataRow(*(click.style(val,fg=col) for val in elt))
+    return elt
+
+for tablefmt in supported_table_formats:
+    for color in click.termui._ansi_colors:
+        newfmt_name = "%s-%s" % (tablefmt,color)
+        srcfmt = tabulate._table_formats[tablefmt]
+        newfmt = tabulate.TableFormat(*( addColorInElt(val, color) for val in srcfmt))
+        supported_formats = supported_formats + (newfmt_name, )
+        tabulate._table_formats[newfmt_name] = newfmt
 
 def adapter(data, headers, table_format=None, preserve_whitespace=False,
             **kwargs):

--- a/cli_helpers/tabular_output/terminaltables_adapter.py
+++ b/cli_helpers/tabular_output/terminaltables_adapter.py
@@ -33,7 +33,7 @@ def adapter(data, headers, table_format=None, **kwargs):
     table_format_handler = {
         'ascii': terminaltables.AsciiTable,
         'double': terminaltables.DoubleTable,
-        'github': terminaltables.GithubFlavoredMarkdownTable
+        'github': terminaltables.GithubFlavoredMarkdownTable,
     }
 
     for tablefmt in table_format_handler.keys():

--- a/cli_helpers/tabular_output/terminaltables_adapter.py
+++ b/cli_helpers/tabular_output/terminaltables_adapter.py
@@ -4,6 +4,9 @@
 import terminaltables
 import itertools
 
+import click
+import click.termui
+
 from cli_helpers.utils import filter_dict_by_key
 from .preprocessors import (convert_to_string, override_missing_value,
                             style_output)
@@ -11,6 +14,17 @@ from .preprocessors import (convert_to_string, override_missing_value,
 supported_formats = ('ascii', 'double', 'github')
 preprocessors = (override_missing_value, convert_to_string, style_output)
 
+def createClassColor(parent, color):
+    class NewTable(parent):
+        def __init__(self, *args, **kw):
+            parent.__init__(self, *args, **kw)
+            for char in [char for char in terminaltables.base_table.BaseTable.__dict__ if char.startswith("CHAR_")]:
+                setattr(self, char, click.style(getattr(self,char), fg=color))
+    return NewTable
+
+for tablefmt in ('ascii', 'double', 'github'):
+    for color in click.termui._ansi_colors:
+        supported_formats = supported_formats + ("%s-%s" % (tablefmt,color), )
 
 def adapter(data, headers, table_format=None, **kwargs):
     """Wrap terminaltables inside a function for TabularOutputFormatter."""
@@ -19,8 +33,12 @@ def adapter(data, headers, table_format=None, **kwargs):
     table_format_handler = {
         'ascii': terminaltables.AsciiTable,
         'double': terminaltables.DoubleTable,
-        'github': terminaltables.GithubFlavoredMarkdownTable,
+        'github': terminaltables.GithubFlavoredMarkdownTable
     }
+
+    for tablefmt in table_format_handler.keys():
+        for color in click.termui._ansi_colors:
+            table_format_handler["%s-%s" % (tablefmt,color)] = createClassColor(table_format_handler[tablefmt], color)
 
     table = table_format_handler[table_format]
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     install_requires=[
         'tabulate[widechars] >= 0.8.2',
         'terminaltables >= 3.0.0',
+        'click >= 4.1',
     ] + py2_reqs,
     extras_require={
         'styles':  ['Pygments >= 1.6'],


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
add color for table. You can use value of table_format: %(table_format)s-%(color)s
List of color : black, red, green, yellow, blue, magenta, cyan, white
List of table_format: ascii, double, github, plain, simple, grid, fancy_grid, pipe, orgtbl, psql, rst

For example: rst-red, double-green, ...


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
