### PR TITLE
use safe float (2578310786669609 / pow(2, 50) == 2.29)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ TBD
 (to be released)
 
 * Copy unit test from pgcli
+* Use safe float for unit test
 
 Version 1.0.1
 -------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
+autopep8==1.3.3
 codecov==2.0.9
 coverage==4.3.4
-git+https://github.com/hayd/pep8radius.git@c8aebd0e1d272160896124e104773b97a6249c3e#egg=pep8radius
+pep8radius
 pytest==3.0.7
 pytest-cov==2.4.0
 Sphinx==1.5.5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,7 @@ def test_to_string_bytes():
 def test_to_string_non_bytes():
     """Test that to_string() converts non-bytes to a string."""
     assert utils.to_string(1) == '1'
-    assert utils.to_string(2.33) == '2.33'
+    assert utils.to_string(2.29) == '2.29'
 
 
 def test_intlen_with_decimal():


### PR DESCRIPTION
## Description
Use a safe float for the unit tests


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
