### PR TITLE
 Fix writing non-ascii characters to config files. 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Version TBD
 
 (released on TBD)
 
+* Fix issue with writing non-ASCII characters to config files.
 * Run tests on Python 3.7.
 
 Version 1.1.0

--- a/cli_helpers/config.py
+++ b/cli_helpers/config.py
@@ -44,7 +44,7 @@ class Config(UserDict, object):
                  validate=False, write_default=False, additional_dirs=()):
         super(Config, self).__init__()
         #: The :class:`ConfigObj` instance.
-        self.data = ConfigObj()
+        self.data = ConfigObj(encoding='utf8')
 
         self.default = {}
         self.default_file = self.default_config = None
@@ -84,6 +84,10 @@ class Config(UserDict, object):
             self.default_config = ConfigObj(configspec=self.default_file,
                                             list_values=False, _inspec=True,
                                             encoding='utf8')
+
+            # ConfigObj does not set the encoding on the configspec.
+            self.default_config.configspec.encoding = 'utf8'
+
             valid = self.default_config.validate(Validator(), copy=True,
                                                  preserve_errors=True)
             if valid is not True:
@@ -161,6 +165,10 @@ class Config(UserDict, object):
         try:
             config = ConfigObj(infile=f, configspec=configspec,
                                interpolation=False, encoding='utf8')
+
+            # ConfigObj does not set the encoding on the configspec.
+            if config.configspec is not None:
+                config.configspec.encoding = 'utf8'
         except ConfigObjError as e:
             logger.warning(
                 'Unable to parse line {} of config file {}'.format(

--- a/tests/config_data/configrc
+++ b/tests/config_data/configrc
@@ -13,6 +13,6 @@ test_boolean_default = True
 
 test_string_file = '~/myfile'
 
-test_option = 'foobar'
+test_option = 'foobar✔'
 
 [section2]

--- a/tests/config_data/configspecrc
+++ b/tests/config_data/configspecrc
@@ -15,6 +15,6 @@ test_boolean = boolean()
 
 test_string_file = string(default='~/myfile')
 
-test_option = option('foo', 'bar', 'foobar', default='foobar')
+test_option = option('foo', 'bar', 'foobar', 'foobar✔', default='foobar✔')
 
 [section2]

--- a/tests/config_data/invalid_configrc
+++ b/tests/config_data/invalid_configrc
@@ -13,6 +13,6 @@ test_boolean_default True
 
 test_string_file = '~/myfile'
 
-test_option = 'foobar'
+test_option = 'foobar✔'
 
 [section2]

--- a/tests/config_data/invalid_configspecrc
+++ b/tests/config_data/invalid_configspecrc
@@ -15,6 +15,6 @@ test_boolean = bool(default=False)
 
 test_string_file = string(default='~/myfile')
 
-test_option = option('foo', 'bar', 'foobar', default='foobar')
+test_option = option('foo', 'bar', 'foobar', 'foobar✔', default='foobar✔')
 
 [section2]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ DEFAULT_CONFIG = {
     'section':  {
         'test_boolean_default': 'True',
         'test_string_file': '~/myfile',
-        'test_option': 'foobar'
+        'test_option': 'foobar✔'
     },
     'section2': {}
 }
@@ -27,7 +27,7 @@ DEFAULT_VALID_CONFIG = {
     'section':  {
         'test_boolean_default': True,
         'test_string_file': '~/myfile',
-        'test_option': 'foobar'
+        'test_option': 'foobar✔'
     },
     'section2': {}
 }
@@ -178,6 +178,7 @@ def test_write_and_read_default_config_from_configspec(temp_dir=None):
     config = _mocked_user_config(temp_dir, APP_NAME, APP_AUTHOR, config_file,
                                  default=default_file, validate=True)
     config.read_default_config()
+    assert config.default_config.encoding == 'utf8'
     config.write_default_config()
 
     user_config = _mocked_user_config(temp_dir, APP_NAME, APP_AUTHOR,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -178,7 +178,6 @@ def test_write_and_read_default_config_from_configspec(temp_dir=None):
     config = _mocked_user_config(temp_dir, APP_NAME, APP_AUTHOR, config_file,
                                  default=default_file, validate=True)
     config.read_default_config()
-    assert config.default_config.encoding == 'utf8'
     config.write_default_config()
 
     user_config = _mocked_user_config(temp_dir, APP_NAME, APP_AUTHOR,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

In trying to get mycli's tests working with CLI Helpers for config reading/writing, I ran into an issue with writing non-ASCII characters to a config file. This fixes that.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
