### PR TITLE
Update version of twine and use twine check.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Version TBD
 (released on TBD)
 
 * Run tests on Python 3.7.
+* Use twine check during packaging tests.
 
 Version 1.1.0
 -------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ pytest==3.0.7
 pytest-cov==2.4.0
 Sphinx==1.5.5
 tox==2.7.0
-twine==1.8.1
+twine==1.12.1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     include_package_data=True,
     description='Helpers for building command-line apps',
     long_description=readme,
+    long_description_content_type='text/x-rst',
     install_requires=[
         'configobj >= 5.0.5',
         'tabulate[widechars] >= 0.8.2',

--- a/tox.ini
+++ b/tox.ini
@@ -34,10 +34,13 @@ commands =
 [testenv:packaging]
 deps =
     check-manifest
-    readme_renderer
+    readme_renderer[md]
+    -r{toxinidir}/requirements-dev.txt
 commands =
     check-manifest
-    ./setup.py check -m -r -s
+    ./setup.py sdist
+    twine check dist/*
+    ./setup.py check -m -s
 
 [testenv:cov-init]
 setenv =


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
- Updates twine
- Uses `twine check` since `python setup.py check -r` is deprecated.
- Builds the source distribution in the packaging tests (so twine can check the description in it).
- Adds the [missing content type metadata](https://packaging.python.org/guides/making-a-pypi-friendly-readme/).


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
