### PR TITLE
rename tsv to csv-tab, add new tsv output adapter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Version TBD
 
 * Run tests on Python 3.7.
 * Use twine check during packaging tests.
+* Rename old tsv format to csv-tab (because it add quotes), introduce new tsv output adapter
 
 Version 1.1.0
 -------------

--- a/cli_helpers/tabular_output/delimited_output_adapter.py
+++ b/cli_helpers/tabular_output/delimited_output_adapter.py
@@ -8,7 +8,7 @@ from cli_helpers.compat import csv, StringIO
 from cli_helpers.utils import filter_dict_by_key
 from .preprocessors import bytes_to_string, override_missing_value
 
-supported_formats = ('csv', 'tsv')
+supported_formats = ('csv', 'csv-tab')
 preprocessors = (override_missing_value, bytes_to_string)
 
 
@@ -29,7 +29,7 @@ def adapter(data, headers, table_format='csv', **kwargs):
             'quotechar', 'quoting', 'skipinitialspace', 'strict')
     if table_format == 'csv':
         delimiter = ','
-    elif table_format == 'tsv':
+    elif table_format == 'csv-tab':
         delimiter = '\t'
     else:
         raise ValueError('Invalid table_format specified.')

--- a/cli_helpers/tabular_output/output_formatter.py
+++ b/cli_helpers/tabular_output/output_formatter.py
@@ -8,7 +8,7 @@ from cli_helpers.compat import (text_type, binary_type, int_types, float_types,
                                 zip_longest)
 from cli_helpers.utils import unique_items
 from . import (delimited_output_adapter, vertical_table_adapter,
-               tabulate_adapter, terminaltables_adapter)
+               tabulate_adapter, terminaltables_adapter, tsv_output_adapter)
 from decimal import Decimal
 
 import itertools
@@ -219,3 +219,9 @@ for terminaltables_format in terminaltables_adapter.supported_formats:
         terminaltables_adapter.preprocessors +
         (terminaltables_adapter.style_output_table(terminaltables_format),),
         {'table_format': terminaltables_format, 'missing_value': MISSING_VALUE})
+
+for tsv_format in tsv_output_adapter.supported_formats:
+    TabularOutputFormatter.register_new_formatter(
+        tsv_format, tsv_output_adapter.adapter,
+        tsv_output_adapter.preprocessors,
+        {'table_format': tsv_format, 'missing_value': ''})

--- a/cli_helpers/tabular_output/tsv_output_adapter.py
+++ b/cli_helpers/tabular_output/tsv_output_adapter.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""A tsv data output adapter"""
+
+from __future__ import unicode_literals
+
+from .preprocessors import bytes_to_string, override_missing_value, convert_to_string
+from itertools import chain
+from cli_helpers.utils import replace
+
+supported_formats = ('tsv',)
+preprocessors = (override_missing_value, bytes_to_string, convert_to_string)
+
+def adapter(data, headers, **kwargs):
+    """Wrap the formatting inside a function for TabularOutputFormatter."""
+    for row in chain((headers,), data):
+        yield "\t".join((replace(r, (('\n', r'\n'), ('\t', r'\t'))) for r in row))

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -51,3 +51,9 @@ _ansi_re = re.compile('\033\[((?:\d|;)*)([a-zA-Z])')
 def strip_ansi(value):
     """Strip the ANSI escape sequences from a string."""
     return _ansi_re.sub('', value)
+
+def replace(s, replace):
+    """Replace multiple values in a string"""
+    for r in replace:
+        s = s.replace(*r)
+    return s

--- a/tests/tabular_output/test_delimited_output_adapter.py
+++ b/tests/tabular_output/test_delimited_output_adapter.py
@@ -14,21 +14,21 @@ def test_csv_wrapper():
     # Test comma-delimited output.
     data = [['abc', '1'], ['d', '456']]
     headers = ['letters', 'number']
-    output = delimited_output_adapter.adapter(iter(data), headers)
+    output = delimited_output_adapter.adapter(iter(data), headers, dialect='unix')
     assert "\n".join(output) == dedent('''\
-        letters,number\n\
-        abc,1\n\
-        d,456''')
+        "letters","number"\n\
+        "abc","1"\n\
+        "d","456"''')
 
     # Test tab-delimited output.
     data = [['abc', '1'], ['d', '456']]
     headers = ['letters', 'number']
     output = delimited_output_adapter.adapter(
-        iter(data), headers, table_format='tsv')
+        iter(data), headers, table_format='csv-tab', dialect='unix')
     assert "\n".join(output) == dedent('''\
-        letters\tnumber\n\
-        abc\t1\n\
-        d\t456''')
+        "letters"\t"number"\n\
+        "abc"\t"1"\n\
+        "d"\t"456"''')
 
     with pytest.raises(ValueError):
         output = delimited_output_adapter.adapter(

--- a/tests/tabular_output/test_tsv_output_adapter.py
+++ b/tests/tabular_output/test_tsv_output_adapter.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Test the tsv delimited output adapter."""
+
+from __future__ import unicode_literals
+from textwrap import dedent
+
+import pytest
+
+from cli_helpers.tabular_output import tsv_output_adapter
+
+
+def test_tsv_wrapper():
+    """Test the tsv output adapter."""
+    # Test tab-delimited output.
+    data = [['ab\r\nc', '1'], ['d', '456']]
+    headers = ['letters', 'number']
+    output = tsv_output_adapter.adapter(
+        iter(data), headers, table_format='tsv')
+    assert "\n".join(output) == dedent('''\
+        letters\tnumber\n\
+        ab\r\\nc\t1\n\
+        d\t456''')
+
+
+def test_unicode_with_tsv():
+    """Test that the tsv wrapper can handle non-ascii characters."""
+    data = [['观音', '1'], ['Ποσειδῶν', '456']]
+    headers = ['letters', 'number']
+    output = tsv_output_adapter.adapter(data, headers)
+    assert "\n".join(output) == dedent('''\
+        letters\tnumber\n\
+        观音\t1\n\
+        Ποσειδῶν\t456''')


### PR DESCRIPTION
## Description
Rename old tsv format to csv-tab (because it add quotes), introduce new tsv output adapter.

More information about tsv: 
https://en.wikipedia.org/wiki/Tab-separated_values
(links to: https://www.iana.org/assignments/media-types/text/tab-separated-values)

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
