### PR TITLE
Truncate very large fields for tabular display.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,8 @@ Version TBD
 
 * Run tests on Python 3.7.
 * Use twine check during packaging tests.
-* Rename old tsv format to csv-tab (because it add quotes), introduce new tsv output adapter
+* Rename old tsv format to csv-tab (because it add quotes), introduce new tsv output adapter.
+* Truncate long fields for tabular display.
 
 Version 1.1.0
 -------------

--- a/cli_helpers/tabular_output/output_formatter.py
+++ b/cli_helpers/tabular_output/output_formatter.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 import itertools
 
 MISSING_VALUE = '<null>'
+MAX_FIELD_WIDTH = 5000
 
 TYPES = {
     type(None): 0,
@@ -198,30 +199,30 @@ for vertical_format in vertical_table_adapter.supported_formats:
     TabularOutputFormatter.register_new_formatter(
         vertical_format, vertical_table_adapter.adapter,
         vertical_table_adapter.preprocessors,
-        {'table_format': vertical_format, 'missing_value': MISSING_VALUE})
+        {'table_format': vertical_format, 'missing_value': MISSING_VALUE, 'max_field_width': None})
 
 for delimited_format in delimited_output_adapter.supported_formats:
     TabularOutputFormatter.register_new_formatter(
         delimited_format, delimited_output_adapter.adapter,
         delimited_output_adapter.preprocessors,
-        {'table_format': delimited_format, 'missing_value': ''})
+        {'table_format': delimited_format, 'missing_value': '', 'max_field_width': None})
 
 for tabulate_format in tabulate_adapter.supported_formats:
     TabularOutputFormatter.register_new_formatter(
         tabulate_format, tabulate_adapter.adapter,
         tabulate_adapter.preprocessors +
         (tabulate_adapter.style_output_table(tabulate_format),),
-        {'table_format': tabulate_format, 'missing_value': MISSING_VALUE})
+        {'table_format': tabulate_format, 'missing_value': MISSING_VALUE, 'max_field_width': MAX_FIELD_WIDTH})
 
 for terminaltables_format in terminaltables_adapter.supported_formats:
     TabularOutputFormatter.register_new_formatter(
         terminaltables_format, terminaltables_adapter.adapter,
         terminaltables_adapter.preprocessors +
         (terminaltables_adapter.style_output_table(terminaltables_format),),
-        {'table_format': terminaltables_format, 'missing_value': MISSING_VALUE})
+        {'table_format': terminaltables_format, 'missing_value': MISSING_VALUE, 'max_field_width': MAX_FIELD_WIDTH})
 
 for tsv_format in tsv_output_adapter.supported_formats:
     TabularOutputFormatter.register_new_formatter(
         tsv_format, tsv_output_adapter.adapter,
         tsv_output_adapter.preprocessors,
-        {'table_format': tsv_format, 'missing_value': ''})
+        {'table_format': tsv_format, 'missing_value': '', 'max_field_width': None})

--- a/cli_helpers/tabular_output/output_formatter.py
+++ b/cli_helpers/tabular_output/output_formatter.py
@@ -14,7 +14,7 @@ from decimal import Decimal
 import itertools
 
 MISSING_VALUE = '<null>'
-MAX_FIELD_WIDTH = 5000
+MAX_FIELD_WIDTH = 500
 
 TYPES = {
     type(None): 0,

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -32,7 +32,6 @@ def convert_to_string(data, headers, **_):
 
     :param iterable data: An :term:`iterable` (e.g. list) of rows.
     :param iterable headers: The column headers.
-    :param int max_field_width: Width to truncate field for display
     :return: The processed data and headers.
     :rtype: tuple
 

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -8,7 +8,7 @@ from cli_helpers.compat import (text_type, int_types, float_types,
                                 HAS_PYGMENTS, Terminal256Formatter, StringIO)
 
 
-def convert_to_string(data, headers, **_):
+def convert_to_string(data, headers, max_field_width=None, **_):
     """Convert all *data* and *headers* to strings.
 
     Binary data that cannot be decoded is converted to a hexadecimal
@@ -16,12 +16,13 @@ def convert_to_string(data, headers, **_):
 
     :param iterable data: An :term:`iterable` (e.g. list) of rows.
     :param iterable headers: The column headers.
+    :param int max_field_width: Width to truncate field for display
     :return: The processed data and headers.
     :rtype: tuple
 
     """
-    return (([utils.to_string(v) for v in row] for row in data),
-            [utils.to_string(h) for h in headers])
+    return (([utils.to_string(v, max_field_width) for v in row] for row in data),
+            [utils.to_string(h, max_field_width) for h in headers])
 
 
 def override_missing_value(data, headers, missing_value='', **_):
@@ -40,7 +41,7 @@ def override_missing_value(data, headers, missing_value='', **_):
             headers)
 
 
-def bytes_to_string(data, headers, **_):
+def bytes_to_string(data, headers, max_field_width=None, **_):
     """Convert all *data* and *headers* bytes to strings.
 
     Binary data that cannot be decoded is converted to a hexadecimal
@@ -48,12 +49,13 @@ def bytes_to_string(data, headers, **_):
 
     :param iterable data: An :term:`iterable` (e.g. list) of rows.
     :param iterable headers: The column headers.
+    :param int max_field_width: Width to truncate field for display
     :return: The processed data and headers.
     :rtype: tuple
 
     """
-    return (([utils.bytes_to_string(v) for v in row] for row in data),
-            [utils.bytes_to_string(h) for h in headers])
+    return (([utils.bytes_to_string(v, max_field_width) for v in row] for row in data),
+            [utils.bytes_to_string(h, max_field_width) for h in headers])
 
 
 def align_decimals(data, headers, column_types=(), **_):

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -8,7 +8,23 @@ from cli_helpers.compat import (text_type, int_types, float_types,
                                 HAS_PYGMENTS, Terminal256Formatter, StringIO)
 
 
-def convert_to_string(data, headers, max_field_width=None, **_):
+def truncate_string(data, headers, max_field_width=None, **_):
+    """Truncate very long strings. Only needed for tabular
+    representation, because trying to tabulate very long data
+    is problematic in terms of performance, and does not make any
+    sense visually.
+
+    :param iterable data: An :term:`iterable` (e.g. list) of rows.
+    :param iterable headers: The column headers.
+    :param int max_field_width: Width to truncate field for display
+    :return: The processed data and headers.
+    :rtype: tuple
+    """
+    return (([utils.truncate_string(v, max_field_width) for v in row] for row in data),
+            [utils.truncate_string(h, max_field_width) for h in headers])
+
+
+def convert_to_string(data, headers, **_):
     """Convert all *data* and *headers* to strings.
 
     Binary data that cannot be decoded is converted to a hexadecimal
@@ -21,8 +37,8 @@ def convert_to_string(data, headers, max_field_width=None, **_):
     :rtype: tuple
 
     """
-    return (([utils.to_string(v, max_field_width) for v in row] for row in data),
-            [utils.to_string(h, max_field_width) for h in headers])
+    return (([utils.to_string(v) for v in row] for row in data),
+            [utils.to_string(h) for h in headers])
 
 
 def override_missing_value(data, headers, missing_value='', **_):
@@ -41,7 +57,7 @@ def override_missing_value(data, headers, missing_value='', **_):
             headers)
 
 
-def bytes_to_string(data, headers, max_field_width=None, **_):
+def bytes_to_string(data, headers, **_):
     """Convert all *data* and *headers* bytes to strings.
 
     Binary data that cannot be decoded is converted to a hexadecimal
@@ -49,13 +65,12 @@ def bytes_to_string(data, headers, max_field_width=None, **_):
 
     :param iterable data: An :term:`iterable` (e.g. list) of rows.
     :param iterable headers: The column headers.
-    :param int max_field_width: Width to truncate field for display
     :return: The processed data and headers.
     :rtype: tuple
 
     """
-    return (([utils.bytes_to_string(v, max_field_width) for v in row] for row in data),
-            [utils.bytes_to_string(h, max_field_width) for h in headers])
+    return (([utils.bytes_to_string(v) for v in row] for row in data),
+            [utils.bytes_to_string(h) for h in headers])
 
 
 def align_decimals(data, headers, column_types=(), **_):

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -2,7 +2,7 @@
 """Format adapter for the tabulate module."""
 
 from cli_helpers.utils import filter_dict_by_key
-from .preprocessors import (convert_to_string, override_missing_value,
+from .preprocessors import (convert_to_string, truncate_string, override_missing_value,
                             style_output, HAS_PYGMENTS, Terminal256Formatter, StringIO)
 
 import tabulate
@@ -13,7 +13,7 @@ supported_table_formats = ('plain', 'simple', 'grid', 'fancy_grid', 'pipe',
                            'orgtbl', 'psql', 'rst')
 supported_formats = supported_markup_formats + supported_table_formats
 
-preprocessors = (override_missing_value, convert_to_string, style_output)
+preprocessors = (override_missing_value, convert_to_string, truncate_string, style_output)
 
 
 def style_output_table(format_name=""):

--- a/cli_helpers/tabular_output/terminaltables_adapter.py
+++ b/cli_helpers/tabular_output/terminaltables_adapter.py
@@ -5,11 +5,11 @@ import terminaltables
 import itertools
 
 from cli_helpers.utils import filter_dict_by_key
-from .preprocessors import (convert_to_string, override_missing_value,
+from .preprocessors import (convert_to_string, truncate_string, override_missing_value,
                             style_output, HAS_PYGMENTS, Terminal256Formatter, StringIO)
 
 supported_formats = ('ascii', 'double', 'github')
-preprocessors = (override_missing_value, convert_to_string, style_output)
+preprocessors = (override_missing_value, convert_to_string, truncate_string, style_output)
 
 table_format_handler = {
     'ascii': terminaltables.AsciiTable,

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -7,32 +7,33 @@ import re
 from cli_helpers.compat import binary_type, text_type
 
 
-def bytes_to_string(b, max_width=None):
-    """Convert bytes *b* to a string. Optionally truncate.
+def bytes_to_string(b):
+    """Convert bytes *b* to a string.
 
     Hexlify bytes that can't be decoded.
 
     """
     if isinstance(b, binary_type):
         try:
-            val = b.decode('utf8')
+            return b.decode('utf8')
         except UnicodeDecodeError:
-            val = '0x' + binascii.hexlify(b).decode('ascii')
-        if max_width is not None:
-            val = val[:max_width]
-        return val
+            return '0x' + binascii.hexlify(b).decode('ascii')
     return b
 
 
-def to_string(value, max_width=None):
-    """Convert *value* to a string. Optionally truncate."""
+def to_string(value):
+    """Convert *value* to a string."""
     if isinstance(value, binary_type):
-        val = bytes_to_string(value)
+        return bytes_to_string(value)
     else:
-        val = text_type(value)
-    if max_width is not None:
-        val = val[:max_width]
-    return val
+        return text_type(value)
+
+
+def truncate_string(value, max_width=None):
+    """Truncate string values."""
+    if isinstance(value, text_type) and max_width is not None and len(value) > max_width:
+        return value[:max_width]
+    return value
 
 
 def intlen(n):

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -7,26 +7,32 @@ import re
 from cli_helpers.compat import binary_type, text_type
 
 
-def bytes_to_string(b):
-    """Convert bytes *b* to a string.
+def bytes_to_string(b, max_width=None):
+    """Convert bytes *b* to a string. Optionally truncate.
 
     Hexlify bytes that can't be decoded.
 
     """
     if isinstance(b, binary_type):
         try:
-            return b.decode('utf8')
+            val = b.decode('utf8')
         except UnicodeDecodeError:
-            return '0x' + binascii.hexlify(b).decode('ascii')
+            val = '0x' + binascii.hexlify(b).decode('ascii')
+        if max_width is not None:
+            val = val[:max_width]
+        return val
     return b
 
 
-def to_string(value):
-    """Convert *value* to a string."""
+def to_string(value, max_width=None):
+    """Convert *value* to a string. Optionally truncate."""
     if isinstance(value, binary_type):
-        return bytes_to_string(value)
+        val = bytes_to_string(value)
     else:
-        return text_type(value)
+        val = text_type(value)
+    if max_width is not None:
+        val = val[:max_width]
+    return val
 
 
 def intlen(n):
@@ -48,9 +54,11 @@ def unique_items(seq):
 
 _ansi_re = re.compile('\033\[((?:\d|;)*)([a-zA-Z])')
 
+
 def strip_ansi(value):
     """Strip the ANSI escape sequences from a string."""
     return _ansi_re.sub('', value)
+
 
 def replace(s, replace):
     """Replace multiple values in a string"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,12 +22,6 @@ def test_bytes_to_string_non_bytes():
     assert utils.bytes_to_string(1) == 1
 
 
-def test_bytes_to_string_truncate():
-    """Test that bytes_to_string() truncates if requested."""
-    byte_val = ('x' * 1000).encode('utf-8')
-    assert utils.bytes_to_string(byte_val, 10) == 'x' * 10
-
-
 def test_to_string_bytes():
     """Test that to_string() converts bytes to a string."""
     assert utils.to_string(b"foo") == 'foo'
@@ -39,10 +33,10 @@ def test_to_string_non_bytes():
     assert utils.to_string(2.29) == '2.29'
 
 
-def test_to_string_truncate():
-    """Test that to_string() truncates if requested."""
+def test_truncate_string():
+    """Test string truncate preprocessor."""
     val = 'x' * 1000
-    assert utils.to_string(val, 10) == 'x' * 10
+    assert utils.truncate_string(val, 10) == 'x' * 10
 
 
 def test_intlen_with_decimal():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ def test_bytes_to_string_non_bytes():
 
 def test_bytes_to_string_truncate():
     """Test that bytes_to_string() truncates if requested."""
-    byte_val = bytes('x' * 1000, 'utf-8')
+    byte_val = ('x' * 1000).encode('utf-8')
     assert utils.bytes_to_string(byte_val, 10) == 'x' * 10
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,12 @@ def test_bytes_to_string_non_bytes():
     assert utils.bytes_to_string(1) == 1
 
 
+def test_bytes_to_string_truncate():
+    """Test that bytes_to_string() truncates if requested."""
+    byte_val = bytes('x' * 1000, 'utf-8')
+    assert utils.bytes_to_string(byte_val, 10) == 'x' * 10
+
+
 def test_to_string_bytes():
     """Test that to_string() converts bytes to a string."""
     assert utils.to_string(b"foo") == 'foo'
@@ -31,6 +37,12 @@ def test_to_string_non_bytes():
     """Test that to_string() converts non-bytes to a string."""
     assert utils.to_string(1) == '1'
     assert utils.to_string(2.29) == '2.29'
+
+
+def test_to_string_truncate():
+    """Test that to_string() truncates if requested."""
+    val = 'x' * 1000
+    assert utils.to_string(val, 10) == 'x' * 10
 
 
 def test_intlen_with_decimal():


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Attempt to fix https://github.com/dbcli/pgcli/issues/976. This is a pretty crude approach of "Who in the world wants to see more than ~5000~ 500 characters in one field in a tabular display? Nobody. Let's truncate it, otherwise tabulate is going to choke." It is open to suggestions.

Note that this line in `pgcli`:

https://github.com/dbcli/pgcli/blob/7b03f8e2043682aa2d1c06e0f7e8258b2f9c43c5/pgcli/main.py#L1200

does not handle the problem, since 1) the check only happens if `auto_expand` is set, and 2) the check happens after formatting, and formatting taking forever is the actual issue.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
