### PR TITLE
Return the supported formats as a list of unicode strings.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Version TBD
 * Use twine check during packaging tests.
 * Rename old tsv format to csv-tab (because it add quotes), introduce new tsv output adapter.
 * Truncate long fields for tabular display.
+* Return the supported table formats as unicode. 
 
 Version 1.1.0
 -------------

--- a/cli_helpers/tabular_output/output_formatter.py
+++ b/cli_helpers/tabular_output/output_formatter.py
@@ -2,7 +2,6 @@
 """A generic tabular data output formatter interface."""
 
 from __future__ import unicode_literals
-from six import text_type
 from collections import namedtuple
 
 from cli_helpers.compat import (text_type, binary_type, int_types, float_types,
@@ -103,7 +102,7 @@ class TabularOutputFormatter(object):
     @property
     def supported_formats(self):
         """The names of the supported output formats in a :class:`tuple`."""
-        return tuple(map(text_type, self._output_formats.keys()))
+        return tuple(self._output_formats.keys())
 
     @classmethod
     def register_new_formatter(cls, format_name, handler, preprocessors=(),

--- a/cli_helpers/tabular_output/output_formatter.py
+++ b/cli_helpers/tabular_output/output_formatter.py
@@ -2,6 +2,7 @@
 """A generic tabular data output formatter interface."""
 
 from __future__ import unicode_literals
+from six import text_type
 from collections import namedtuple
 
 from cli_helpers.compat import (text_type, binary_type, int_types, float_types,
@@ -102,7 +103,7 @@ class TabularOutputFormatter(object):
     @property
     def supported_formats(self):
         """The names of the supported output formats in a :class:`tuple`."""
-        return tuple(self._output_formats.keys())
+        return tuple(map(text_type, self._output_formats.keys()))
 
     @classmethod
     def register_new_formatter(cls, format_name, handler, preprocessors=(),

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Format adapter for the tabulate module."""
 
+from __future__ import unicode_literals
+
 from cli_helpers.utils import filter_dict_by_key
 from .preprocessors import (convert_to_string, truncate_string, override_missing_value,
                             style_output, HAS_PYGMENTS, Terminal256Formatter, StringIO)

--- a/cli_helpers/tabular_output/terminaltables_adapter.py
+++ b/cli_helpers/tabular_output/terminaltables_adapter.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Format adapter for the terminaltables module."""
 
+from __future__ import unicode_literals
+
 import terminaltables
 import itertools
 


### PR DESCRIPTION
## Description

Completions weren't shown after the \T command because they weren't unicode.