### PR TITLE
Override tab with 4 spaces for terminal tables.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ This project receives help from these awesome contributors:
 
 - Terje Røsten
 - Frederic Aoustin
+- Zhaolong Zhu
 
 
 Thanks

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,7 +10,8 @@ Version TBD
 * Use twine check during packaging tests.
 * Rename old tsv format to csv-tab (because it add quotes), introduce new tsv output adapter.
 * Truncate long fields for tabular display.
-* Return the supported table formats as unicode. 
+* Return the supported table formats as unicode.
+* Override tab with 4 spaces for terminal tables.
 
 Version 1.1.0
 -------------

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -56,6 +56,21 @@ def override_missing_value(data, headers, missing_value='', **_):
             headers)
 
 
+def override_tab_value(data, headers, new_value='    ', **_):
+    """Override tab values in the *data* with *new_value*.
+
+    :param iterable data: An :term:`iterable` (e.g. list) of rows.
+    :param iterable headers: The column headers.
+    :param new_value: The new value to use for tab.
+    :return: The processed data and headers.
+    :rtype: tuple
+
+    """
+    return (([v.replace('\t', new_value) if isinstance(v, text_type) else v
+              for v in row] for row in data),
+            headers)
+
+
 def bytes_to_string(data, headers, **_):
     """Convert all *data* and *headers* bytes to strings.
 

--- a/cli_helpers/tabular_output/terminaltables_adapter.py
+++ b/cli_helpers/tabular_output/terminaltables_adapter.py
@@ -8,10 +8,14 @@ import itertools
 
 from cli_helpers.utils import filter_dict_by_key
 from .preprocessors import (convert_to_string, truncate_string, override_missing_value,
-                            style_output, HAS_PYGMENTS, Terminal256Formatter, StringIO)
+                            style_output, HAS_PYGMENTS, Terminal256Formatter, StringIO,
+                            override_tab_value)
 
 supported_formats = ('ascii', 'double', 'github')
-preprocessors = (override_missing_value, convert_to_string, truncate_string, style_output)
+preprocessors = (
+    override_missing_value, convert_to_string, override_tab_value,
+    truncate_string, style_output
+)
 
 table_format_handler = {
     'ascii': terminaltables.AsciiTable,

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -9,7 +9,7 @@ import pytest
 from cli_helpers.compat import HAS_PYGMENTS
 from cli_helpers.tabular_output.preprocessors import (
     align_decimals, bytes_to_string, convert_to_string, quote_whitespaces,
-    override_missing_value, style_output, format_numbers)
+    override_missing_value, override_tab_value, style_output, format_numbers)
 
 if HAS_PYGMENTS:
     from pygments.style import Style
@@ -38,6 +38,17 @@ def test_override_missing_values():
     results = override_missing_value(data, headers, missing_value='<EMPTY>')
 
     assert expected == (list(results[0]), results[1])
+
+
+def test_override_tab_value():
+    """Test the override_tab_value() function."""
+    data = [[1, '\tJohn'], [2, 'Jill']]
+    headers = ['id', 'name']
+    expected = ([[1, '    John'], [2, 'Jill']], ['id', 'name'])
+    results = override_tab_value(data, headers)
+
+    assert expected == (list(results[0]), results[1])
+
 
 def test_bytes_to_string():
     """Test the bytes_to_string() function."""


### PR DESCRIPTION
## Description

### Problem
If data contain `tab`, the table output format looks weird. For example:

```
+-----------------------+
| tables                |
+-----------------------+
| CREATE TABLE aaa (    |
| 	bbb varchar not null |
+-----------------------+
```

It's because table formatter treats a tab as a normal character while the terminal treats it in a different way (e.g. 4 or 8 spaces wide).

### How to reproduce?

``` python
from cli_helpers.tabular_output import TabularOutputFormatter

table = [["CREATE TABLE aaa ("], ["\tbbb varchar not null"]]
headers = ["tables"]

def format_table(table, headers, formatter):
    for i in formatter.format_output(table, headers):
        print(i)

formatter = TabularOutputFormatter('ascii')
format_table(table, headers, formatter)
```

### Possible solutions

We can override `tab` with 4 spaces, `\t` or `↹`:

#### Override with 4 spaces 

```
+--------------------------+
| tables                   |
+--------------------------+
| CREATE TABLE aaa (       |
|     bbb varchar not null |
+--------------------------+
```

#### Override with  `\t`

```
+------------------------+
| tables                 |
+------------------------+
| CREATE TABLE aaa (     |
| \tbbb varchar not null |
+------------------------+
```

#### Override with `↹`

```
+-----------------------+
| tables                |
+-----------------------+
| CREATE TABLE aaa (    |
| ↹bbb varchar not null |
+-----------------------+
```

After comparing the output format, I decided to use 4 spaces.

## Related issue

https://github.com/dbcli/litecli/issues/37#issuecomment-453768577

## Checklist

- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
