### PR TITLE
Pin to Pygments >= 2.4.0 for tests and drop Python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
       python: 2.7
       env: TOXENV=py27
     - os: linux
-      python: 3.4
-      env: TOXENV=py34
-    - os: linux
       python: 3.5
       env: TOXENV=py35
     - os: linux

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+TBD
+---
+
+* Pin Pygments to >= 2.4.0 for tests.
+
 Version 1.2.0
 -------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ TBD
 ---
 
 * Pin Pygments to >= 2.4.0 for tests.
+* Remove Python 3.4 from tests and Trove classifier.
 
 Version 1.2.0
 -------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -193,7 +193,7 @@ def style_output(data, headers, style=None,
         class YourStyle(Style):
             default_style = ""
             styles = {
-                Token.Output.Header: 'bold #ansired',
+                Token.Output.Header: 'bold ansibrightred',
                 Token.Output.OddRow: 'bg:#eee #111',
                 Token.Output.EvenRow: '#0f0'
             }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ codecov==2.0.9
 coverage==4.3.4
 mock==2.0.0
 pep8radius
+Pygments>=2.4.0
 pytest==3.0.7
 pytest-cov==2.4.0
 Sphinx==1.5.5

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -154,7 +154,7 @@ def test_style_output():
     class CliStyle(Style):
         default_style = ""
         styles = {
-            Token.Output.Header: 'bold #ansired',
+            Token.Output.Header: 'bold ansibrightred',
             Token.Output.OddRow: 'bg:#eee #111',
             Token.Output.EvenRow: '#0f0'
         }
@@ -176,7 +176,7 @@ def test_style_output_with_newlines():
     class CliStyle(Style):
         default_style = ""
         styles = {
-            Token.Output.Header: 'bold #ansired',
+            Token.Output.Header: 'bold ansibrightred',
             Token.Output.OddRow: 'bg:#eee #111',
             Token.Output.EvenRow: '#0f0'
         }
@@ -200,7 +200,7 @@ def test_style_output_custom_tokens():
     class CliStyle(Style):
         default_style = ""
         styles = {
-            Token.Results.Headers: 'bold #ansired',
+            Token.Results.Headers: 'bold ansibrightred',
             Token.Results.OddRows: 'bg:#eee #111',
             Token.Results.EvenRows: '#0f0'
         }

--- a/tests/tabular_output/test_tabulate_adapter.py
+++ b/tests/tabular_output/test_tabulate_adapter.py
@@ -63,7 +63,7 @@ def test_style_output_table():
     class CliStyle(Style):
         default_style = ""
         styles = {
-            Token.Output.TableSeparator: '#ansired',
+            Token.Output.TableSeparator: 'ansibrightred',
         }
     headers = ['h1', 'h2']
     data = [['观音', '2'], ['Ποσειδῶν', 'b']]

--- a/tests/tabular_output/test_terminaltables_adapter.py
+++ b/tests/tabular_output/test_terminaltables_adapter.py
@@ -36,7 +36,7 @@ def test_style_output_table():
     class CliStyle(Style):
         default_style = ""
         styles = {
-            Token.Output.TableSeparator: '#ansired',
+            Token.Output.TableSeparator: 'ansibrightred',
         }
     headers = ['h1', 'h2']
     data = [['观音', '2'], ['Ποσειδῶν', 'b']]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init, py27, py34, py35, py36, py37, noextras, docs, packaging, cov-report
+envlist = cov-init, py27, py35, py36, py37, noextras, docs, packaging, cov-report
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_* CODECOV


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Pygments 2.4.0 included a change to the ANSI color names that are recognized. Some of our tox environments in Travis CI were using 2.4.0 and others were using 2.3.1, which led to some tests failing, but not all.

This fixes that by switching to the 2.4.0 color name formats and pinning the version in requirements-dev.txt.

**Note:** This also drops Python 3.4 from the test suite and Trove classifiers since 3.4 doesn't support Pygments 2.4.0. It was end-of-lifed in March 2019.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
