### PR TITLE
Fix deprecation warning regarding invalid escape sequences.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ This project receives help from these awesome contributors:
 - Terje Røsten
 - Frederic Aoustin
 - Zhaolong Zhu
+- Karthikeyan Singaravelan
 
 
 Thanks

--- a/cli_helpers/config.py
+++ b/cli_helpers/config.py
@@ -204,9 +204,9 @@ def get_user_config_dir(app_name, app_author, roaming=True, force_xdg=True):
     Unix:
       ``~/.config/my-app``
     Windows 7 (roaming):
-      ``C:\\Users\<user>\AppData\Roaming\Acme\My App``
+      ``C:\\Users\\<user>\\AppData\\Roaming\\Acme\\My App``
     Windows 7 (not roaming):
-      ``C:\\Users\<user>\AppData\Local\Acme\My App``
+      ``C:\\Users\\<user>\\AppData\\Local\\Acme\\My App``
 
     :param app_name: the application name. This should be properly capitalized
                      and can contain whitespace.

--- a/cli_helpers/tabular_output/output_formatter.py
+++ b/cli_helpers/tabular_output/output_formatter.py
@@ -121,7 +121,7 @@ class TabularOutputFormatter(object):
 
     def format_output(self, data, headers, format_name=None,
                       preprocessors=(), column_types=None, **kwargs):
-        """Format the headers and data using a specific formatter.
+        r"""Format the headers and data using a specific formatter.
 
         *format_name* must be a supported formatter (see
         :attr:`supported_formats`).
@@ -179,7 +179,7 @@ class TabularOutputFormatter(object):
 
 
 def format_output(data, headers, format_name, **kwargs):
-    """Format output using *format_name*.
+    r"""Format output using *format_name*.
 
     This is a wrapper around the :class:`TabularOutputFormatter` class.
 

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -55,7 +55,7 @@ def unique_items(seq):
     return [x for x in seq if not (x in seen or seen.add(x))]
 
 
-_ansi_re = re.compile('\033\[((?:\d|;)*)([a-zA-Z])')
+_ansi_re = re.compile('\033\\[((?:\\d|;)*)([a-zA-Z])')
 
 
 def strip_ansi(value):

--- a/tasks.py
+++ b/tasks.py
@@ -48,7 +48,7 @@ class BaseCommand(Command, object):
     def apply_option(self, cmd, option, active=True):
         """Apply a command-line option."""
         return re.sub(r'{{{}\:(?P<option>[^}}]*)}}'.format(option),
-                      '\g<option>' if active else '', cmd)
+                      r'\g<option>' if active else '', cmd)
 
 
 class lint(BaseCommand):


### PR DESCRIPTION
## Description

Fix deprecation warning regarding invalid escape sequences in Python 3.7 . Fix done using https://github.com/asottile/pyupgrade

```
find . -iname '*.py' | grep -Ev 'example|utl|samples|deps' | xargs -P 4 -I{} python3.8 -Wall -m py_compile {} 
./tasks.py:51: DeprecationWarning: invalid escape sequence \g
  '\g<option>' if active else '', cmd)
./cli_helpers/tabular_output/output_formatter.py:124: DeprecationWarning: invalid escape sequence \*
  """Format the headers and data using a specific formatter.
./cli_helpers/tabular_output/output_formatter.py:182: DeprecationWarning: invalid escape sequence \*
  """Format output using *format_name*.
./cli_helpers/utils.py:58: DeprecationWarning: invalid escape sequence \[
  _ansi_re = re.compile('\033\[((?:\d|;)*)([a-zA-Z])')
./cli_helpers/config.py:194: DeprecationWarning: invalid escape sequence \<
  """Returns the config folder for the application.  The default behavior
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
