### PR TITLE
Use built-in unittest.mock module

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,7 +20,7 @@ This project receives help from these awesome contributors:
 - Karthikeyan Singaravelan
 - laixintao
 - Georgy Frolov
-
+- Michał Górny
 
 Thanks
 ------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ TBD
 ---
 
 * Fix newline escaping in plain-text formatters (ascii, double, github)
+* Use built-in unittest.mock instead of mock.
 
 Version 2.0.0
 -------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 autopep8==1.3.3
 codecov==2.0.9
 coverage==4.3.4
-mock==2.0.0
 pep8radius
 Pygments>=2.4.0
 pytest==3.0.7

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import os
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 import pytest
 
 from cli_helpers.compat import MAC, text_type, WIN


### PR DESCRIPTION
## Description
Now that cli_helpers no longer support Python 2, there is no point
in using the external mock package.  Use built-in unittest.mock module
instead.

## Checklist
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).

This is a really trivial change, certainly not copyrightable, so I doubt my name is worth adding there. If you think otherwise, please let me know.