### PR TITLE
Optimizations in output styling

### DIFF
--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """These preprocessor functions are used to process data prior to output."""
 
-import re
 import string
 
 from cli_helpers import utils
@@ -253,10 +252,14 @@ def style_output(data, headers, style=None,
     :rtype: tuple
 
     """
+    from cli_helpers.utils import filter_style_table
+    relevant_styles = filter_style_table(style, header_token, odd_row_token, even_row_token)
     if style and HAS_PYGMENTS:
-        headers = [utils.style_field(header_token, header, style) for header in headers]
-        data = ([utils.style_field(odd_row_token if i % 2 else even_row_token, f, style)
-                 for f in r] for i, r in enumerate(data, 1))
+        if relevant_styles.get(header_token):
+            headers = [utils.style_field(header_token, header, style) for header in headers]
+        if relevant_styles.get(odd_row_token) or relevant_styles.get(even_row_token):
+            data = ([utils.style_field(odd_row_token if i % 2 else even_row_token, f, style)
+                     for f in r] for i, r in enumerate(data, 1))
 
     return iter(data), headers
 

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -4,6 +4,11 @@
 import binascii
 import re
 from functools import lru_cache
+from typing import Dict
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from pygments.style import StyleMeta
 
 from cli_helpers.compat import binary_type, text_type, Terminal256Formatter, StringIO
 
@@ -82,3 +87,20 @@ def style_field(token, field, style):
     s = StringIO()
     formatter.format(((token, field),), s)
     return s.getvalue()
+
+
+def filter_style_table(style: "StyleMeta", *relevant_styles: str) -> Dict:
+    """
+    get a dictionary of styles for given tokens. Typical usage:
+
+    filter_style_table(style, 'Token.Output.EvenRow', 'Token.Output.OddRow') == {
+        'Token.Output.EvenRow': "",
+        'Token.Output.OddRow': "",
+    }
+    """
+    _styles_iter = ((str(key), val) for key, val in getattr(style, 'styles', {}).items())
+    _relevant_styles_iter = filter(
+        lambda tpl: tpl[0] in relevant_styles,
+        _styles_iter
+    )
+    return {key: val for key, val in _relevant_styles_iter}

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -3,6 +3,7 @@
 
 import binascii
 import re
+from functools import lru_cache
 
 from cli_helpers.compat import binary_type, text_type, Terminal256Formatter, StringIO
 
@@ -70,9 +71,14 @@ def replace(s, replace):
     return s
 
 
+@lru_cache()
+def _get_formatter(style) -> Terminal256Formatter:
+    return Terminal256Formatter(style=style)
+
+
 def style_field(token, field, style):
     """Get the styled text for a *field* using *token* type."""
-    formatter = Terminal256Formatter(style=style)
+    formatter = _get_formatter(style)
     s = StringIO()
     formatter.format(((token, field),), s)
     return s.getvalue()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
I did some profiling (prompted by [a mycli issue](https://github.com/dbcli/mycli/issues/873)) and found that during output styling, we spend most of the time recreating the Pygments formatter: 
![image](https://user-images.githubusercontent.com/11982173/83362803-b54a6a00-a39c-11ea-937e-057a90cb7b68.png)
A simple caching gives a noticeable speedup. For example, on [this sample database](https://github.com/datacharmer/test_db) with `ascii` formatter `SELECT * FROM employees LIMIT 40` takes 0.969s before and 0.019s after this change (51x).
