### PR TITLE
Add psql_unicode table format

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ This project receives help from these awesome contributors:
 - laixintao
 - Georgy Frolov
 - Michał Górny
+- Waldir Pimenta
 
 Thanks
 ------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,13 +5,14 @@ TBD
 ---
 
 * Remove dependency on terminaltables
+* Add psql_unicode table format
 
 Version 2.1.0
 -------------
 
 (released on 2020-07-29)
 
-* Speed up ouput styling of tables.
+* Speed up output styling of tables.
 
 Version 2.0.1
 -------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,9 +24,9 @@ Ready to contribute? Here's how to set up CLI Helpers for local development.
     $ pip install virtualenv
     $ virtualenv cli_helpers_dev
 
-   We've just created a virtual environment that we'll use to install all the dependencies
-   and tools we need to work on CLI Helpers. Whenever you want to work on CLI Helpers, you
-   need to activate the virtual environment::
+   We've just created a virtual environment called ``cli_helpers_dev``
+   that we'll use to install all the dependencies and tools we need to work on CLI Helpers.
+   Whenever you want to work on CLI Helpers, you need to activate the virtual environment::
 
     $ source cli_helpers_dev/bin/activate
 
@@ -34,7 +34,7 @@ Ready to contribute? Here's how to set up CLI Helpers for local development.
 
     $ deactivate
 
-5. Install the dependencies and development tools::
+5. From within the virtual environment, install the dependencies and development tools::
 
     $ pip install -r requirements-dev.txt
     $ pip install --editable .
@@ -43,11 +43,14 @@ Ready to contribute? Here's how to set up CLI Helpers for local development.
 
     $ git checkout -b <name-of-bugfix-or-feature> master
 
-7. While you work on your bugfix or feature, be sure to pull the latest changes from ``upstream``. This ensures that your local codebase is up-to-date::
+7. While you work on your bugfix or feature, be sure to pull the latest changes from ``upstream``.
+   This ensures that your local codebase is up-to-date::
 
     $ git pull upstream master
 
-8. When your work is ready for the CLI Helpers team to review it, push your branch to your fork::
+8. When your work is ready for the CLI Helpers team to review it,
+   make sure to add an entry to CHANGELOG file, and add your name to the AUTHORS file.
+   Then, push your branch to your fork::
 
     $ git push origin <name-of-bugfix-or-feature>
 

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -13,6 +13,17 @@ import tabulate
 
 tabulate.MIN_PADDING = 0
 
+tabulate._table_formats['psql_unicode'] = tabulate.TableFormat(
+    lineabove=tabulate.Line("┌", "─", "┬", "┐"),
+    linebelowheader=tabulate.Line("├", "─", "┼", "┤"),
+    linebetweenrows=None,
+    linebelow=tabulate.Line("└", "─", "┴", "┘"),
+    headerrow=tabulate.DataRow("│", "│", "│"),
+    datarow=tabulate.DataRow("│", "│", "│"),
+    padding=1,
+    with_header_hide=None,
+)
+
 tabulate._table_formats['double'] = tabulate.TableFormat(
     lineabove=tabulate.Line("╔", "═", "╦", "╗"),
     linebelowheader=tabulate.Line("╠", "═", "╬", "╣"),
@@ -38,7 +49,7 @@ tabulate._table_formats["ascii"] = tabulate.TableFormat(
 supported_markup_formats = ('mediawiki', 'html', 'latex', 'latex_booktabs',
                             'textile', 'moinmoin', 'jira')
 supported_table_formats = ('ascii', 'plain', 'simple', 'grid', 'fancy_grid', 'pipe',
-                           'orgtbl', 'psql', 'rst', 'github', 'double')
+                           'orgtbl', 'psql', 'psql_unicode', 'rst', 'github', 'double')
 
 supported_formats = supported_markup_formats + supported_table_formats
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -50,7 +50,7 @@ Let's get a list of all the supported format names::
     >>> from cli_helpers.tabular_output import TabularOutputFormatter
     >>> formatter = TabularOutputFormatter()
     >>> formatter.supported_formats
-    ('vertical', 'csv', 'tsv', 'mediawiki', 'html', 'latex', 'latex_booktabs', 'textile', 'moinmoin', 'jira', 'plain', 'simple', 'grid', 'fancy_grid', 'pipe', 'orgtbl', 'psql', 'rst', 'ascii', 'double', 'github')
+    ('vertical', 'csv', 'tsv', 'mediawiki', 'html', 'latex', 'latex_booktabs', 'textile', 'moinmoin', 'jira', 'plain', 'simple', 'grid', 'fancy_grid', 'pipe', 'orgtbl', 'psql', 'psql_unicode', 'rst', 'ascii', 'double', 'github')
 
 You can format your data in any of those supported formats. Let's take the
 same data from our first example and put it in the ``fancy_grid`` format::

--- a/tests/tabular_output/test_tabulate_adapter.py
+++ b/tests/tabular_output/test_tabulate_adapter.py
@@ -27,6 +27,17 @@ def test_tabulate_wrapper():
         | d       |    456 |
         +---------+--------+''')
 
+    data = [['abc', 1], ['d', 456]]
+    headers = ['letters', 'number']
+    output = tabulate_adapter.adapter(iter(data), headers, table_format='psql_unicode')
+    assert "\n".join(output) == dedent('''\
+        ┌─────────┬────────┐
+        │ letters │ number │
+        ├─────────┼────────┤
+        │ abc     │      1 │
+        │ d       │    456 │
+        └─────────┴────────┘''')
+
     data = [['{1,2,3}', '{{1,2},{3,4}}', '{å,魚,текст}'], ['{}', '<null>', '{<null>}']]
     headers = ['bigint_array', 'nested_numeric_array', '配列']
     output = tabulate_adapter.adapter(iter(data), headers, table_format='psql')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Added a new table format to match psql's `\pset linestyle unicode`, as requested in https://github.com/dbcli/pgcli/issues/1029.

It is similar to the `double` format, so we could call it `single` for consistency, but I think `psql_unicode` is clearer.

I've also added a separate commit with a couple small improvements to CONTRIBUTING.rst (which btw is very well written and helpful -- thanks!)


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
