### PR TITLE
Added skip_headers argument to the csv formatter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ TBD
 
 * Remove dependency on terminaltables
 * Add psql_unicode table format
+* Add skip_headers argument to csv formatter
 
 Version 2.1.0
 -------------

--- a/cli_helpers/tabular_output/delimited_output_adapter.py
+++ b/cli_helpers/tabular_output/delimited_output_adapter.py
@@ -23,7 +23,7 @@ class linewriter(object):
         self.line = d
 
 
-def adapter(data, headers, table_format="csv", **kwargs):
+def adapter(data, headers, table_format="csv", skip_header=False, **kwargs):
     """Wrap the formatting inside a function for TabularOutputFormatter."""
     keys = (
         "dialect",
@@ -47,8 +47,10 @@ def adapter(data, headers, table_format="csv", **kwargs):
 
     l = linewriter()
     writer = csv.writer(l, **ckwargs)
-    writer.writerow(headers)
-    yield l.line
+
+    if not kwargs.get("skip_header"):
+        writer.writerow(headers)
+        yield l.line
 
     for row in data:
         l.reset()

--- a/tests/tabular_output/test_delimited_output_adapter.py
+++ b/tests/tabular_output/test_delimited_output_adapter.py
@@ -22,6 +22,18 @@ def test_csv_wrapper():
         "d","456"'''
     )
 
+    # Test skip_headers argument
+    data = [["abc", "1"], ["d", "456"]]
+    headers = ["letters", "number"]
+    output = delimited_output_adapter.adapter(
+        iter(data), headers, dialect="unix", skip_headers=True
+    )
+    assert "\n".join(output) == dedent(
+        '''\
+        "abc","1"\n\
+        "d","456"'''
+    )
+
     # Test tab-delimited output.
     data = [["abc", "1"], ["d", "456"]]
     headers = ["letters", "number"]


### PR DESCRIPTION
## Description
A new argument is needed to implement  `\T csv --skip-headers` in mycli, see https://github.com/dbcli/mycli/issues/872



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
