### PR TITLE
hexlify unprintable bytes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ This project receives help from these awesome contributors:
 - Georgy Frolov
 - Michał Górny
 - Waldir Pimenta
+- Mel Dafert
 
 Thanks
 ------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ TBD
 * Add psql_unicode table format
 * Add minimal table format
 * Fix pip2 installing py3-only versions
+* Format unprintable bytes (eg 0x00, 0x01) as hex
 
 Version 2.1.0
 -------------

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -21,10 +21,16 @@ def bytes_to_string(b):
 
     """
     if isinstance(b, binary_type):
+        needs_hex = False
         try:
-            return b.decode("utf8")
+            result = b.decode("utf8")
+            needs_hex = not result.isprintable()
         except UnicodeDecodeError:
+            needs_hex = True
+        if needs_hex:
             return "0x" + binascii.hexlify(b).decode("ascii")
+        else:
+            return result
     return b
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,13 @@ def test_bytes_to_string_decode_bytes():
     assert utils.bytes_to_string(b"foobar") == "foobar"
 
 
+def test_bytes_to_string_unprintable():
+    """Test that bytes_to_string() hexlifies data that is valid unicode, but unprintable."""
+    assert utils.bytes_to_string(b"\0") == "0x00"
+    assert utils.bytes_to_string(b"\1") == "0x01"
+    assert utils.bytes_to_string(b"a\0") == "0x6100"
+
+
 def test_bytes_to_string_non_bytes():
     """Test that bytes_to_string() returns non-bytes untouched."""
     assert utils.bytes_to_string("abc") == "abc"


### PR DESCRIPTION
## Description
Fixes dbcli/mycli#876.

Some characters like `\0` (null byte) are valid UTF-8, but still considered unprintable.
This can lead to the character being displayed as `^@`, which messes with formatting, or completely cutting off lines in certain pagers.
Byte sequences containing unprintable characters are unlikely to be actual strings, rather than binary data that happens to be unicode-compatible.

This PR converts bytes containing unprintable characters to hex, decided by [str.isprintable](https://docs.python.org/3/library/stdtypes.html#str.isprintable).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
