### PR TITLE
fix table_separator_token passed as string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ This project receives help from these awesome contributors:
 - Michał Górny
 - Waldir Pimenta
 - Mel Dafert
+- Andrii Kohut
 
 Thanks
 ------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ Version 2.2.1
 
 (released on 2022-01-17)
 
-* Fix Token.Output.TableSeparator passed as string
+* Fix pygments tokens passed as strings
 
 Version 2.2.0
 -------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version 2.2.1
+-------------
+
+(released on 2022-01-17)
+
+* Fix Token.Output.TableSeparator passed as string
+
 Version 2.2.0
 -------------
 

--- a/cli_helpers/compat.py
+++ b/cli_helpers/compat.py
@@ -35,11 +35,14 @@ else:
 HAS_PYGMENTS = True
 try:
     from pygments.token import Token
+
     TableSeparator = Token.Output.TableSeparator
+    Null = Token.Output.Null
     from pygments.formatters.terminal256 import Terminal256Formatter
 except ImportError:
     HAS_PYGMENTS = False
     Terminal256Formatter = None
     TableSeparator = None
+    Null = None
 
 float_types = (float, Decimal)

--- a/cli_helpers/compat.py
+++ b/cli_helpers/compat.py
@@ -34,9 +34,12 @@ else:
 
 HAS_PYGMENTS = True
 try:
+    from pygments.token import Token
+    TableSeparator = Token.Output.TableSeparator
     from pygments.formatters.terminal256 import Terminal256Formatter
 except ImportError:
     HAS_PYGMENTS = False
     Terminal256Formatter = None
+    TableSeparator = None
 
 float_types = (float, Decimal)

--- a/cli_helpers/compat.py
+++ b/cli_helpers/compat.py
@@ -2,6 +2,7 @@
 """OS and Python compatibility support."""
 
 from decimal import Decimal
+from types import SimpleNamespace
 import sys
 
 PY2 = sys.version_info[0] == 2
@@ -35,14 +36,21 @@ else:
 HAS_PYGMENTS = True
 try:
     from pygments.token import Token
-
-    TableSeparator = Token.Output.TableSeparator
-    Null = Token.Output.Null
     from pygments.formatters.terminal256 import Terminal256Formatter
 except ImportError:
     HAS_PYGMENTS = False
     Terminal256Formatter = None
-    TableSeparator = None
-    Null = None
+    Token = SimpleNamespace()
+    Token.Output = SimpleNamespace()
+    Token.Output.Header = None
+    Token.Output.OddRow = None
+    Token.Output.EvenRow = None
+    Token.Output.Null = None
+    Token.Output.TableSeparator = None
+    Token.Results = SimpleNamespace()
+    Token.Results.Header = None
+    Token.Results.OddRow = None
+    Token.Results.EvenRow = None
+
 
 float_types = (float, Decimal)

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -4,7 +4,7 @@
 import string
 
 from cli_helpers import utils
-from cli_helpers.compat import text_type, int_types, float_types, HAS_PYGMENTS
+from cli_helpers.compat import text_type, int_types, float_types, HAS_PYGMENTS, Null
 
 
 def truncate_string(
@@ -58,9 +58,9 @@ def override_missing_value(
     data,
     headers,
     style=None,
-    missing_value_token="Token.Output.Null",
+    missing_value_token=Null,
     missing_value="",
-    **_
+    **_,
 ):
     """Override missing values in the *data* with *missing_value*.
 
@@ -251,7 +251,7 @@ def style_output(
     header_token="Token.Output.Header",
     odd_row_token="Token.Output.OddRow",
     even_row_token="Token.Output.EvenRow",
-    **_
+    **_,
 ):
     """Style the *data* and *headers* (e.g. bold, italic, and colors)
 

--- a/cli_helpers/tabular_output/preprocessors.py
+++ b/cli_helpers/tabular_output/preprocessors.py
@@ -4,7 +4,7 @@
 import string
 
 from cli_helpers import utils
-from cli_helpers.compat import text_type, int_types, float_types, HAS_PYGMENTS, Null
+from cli_helpers.compat import text_type, int_types, float_types, HAS_PYGMENTS, Token
 
 
 def truncate_string(
@@ -58,7 +58,7 @@ def override_missing_value(
     data,
     headers,
     style=None,
-    missing_value_token=Null,
+    missing_value_token=Token.Output.Null,
     missing_value="",
     **_,
 ):
@@ -248,9 +248,9 @@ def style_output(
     data,
     headers,
     style=None,
-    header_token="Token.Output.Header",
-    odd_row_token="Token.Output.OddRow",
-    even_row_token="Token.Output.EvenRow",
+    header_token=Token.Output.Header,
+    odd_row_token=Token.Output.OddRow,
+    even_row_token=Token.Output.EvenRow,
     **_,
 ):
     """Style the *data* and *headers* (e.g. bold, italic, and colors)

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 from cli_helpers.utils import filter_dict_by_key
-from cli_helpers.compat import Terminal256Formatter, StringIO
+from cli_helpers.compat import Terminal256Formatter, TableSeparator, StringIO
 from .preprocessors import (
     convert_to_string,
     truncate_string,
@@ -105,7 +105,7 @@ def style_output_table(format_name=""):
         data,
         headers,
         style=None,
-        table_separator_token="Token.Output.TableSeparator",
+        table_separator_token=TableSeparator,
         **_
     ):
         """Style the *table* a(e.g. bold, italic, and colors)

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -106,7 +106,7 @@ def style_output_table(format_name=""):
         headers,
         style=None,
         table_separator_token=TableSeparator,
-        **_
+        **_,
     ):
         """Style the *table* a(e.g. bold, italic, and colors)
 

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 from cli_helpers.utils import filter_dict_by_key
-from cli_helpers.compat import Terminal256Formatter, TableSeparator, StringIO
+from cli_helpers.compat import Terminal256Formatter, Token, StringIO
 from .preprocessors import (
     convert_to_string,
     truncate_string,
@@ -105,7 +105,7 @@ def style_output_table(format_name=""):
         data,
         headers,
         style=None,
-        table_separator_token=TableSeparator,
+        table_separator_token=Token.Output.TableSeparator,
         **_,
     ):
         """Style the *table* a(e.g. bold, italic, and colors)

--- a/cli_helpers/utils.py
+++ b/cli_helpers/utils.py
@@ -104,13 +104,11 @@ def filter_style_table(style: "StyleMeta", *relevant_styles: str) -> Dict:
     """
     get a dictionary of styles for given tokens. Typical usage:
 
-    filter_style_table(style, 'Token.Output.EvenRow', 'Token.Output.OddRow') == {
-        'Token.Output.EvenRow': "",
-        'Token.Output.OddRow': "",
+    filter_style_table(style, Token.Output.EvenRow, Token.Output.OddRow) == {
+        Token.Output.EvenRow: "",
+        Token.Output.OddRow: "",
     }
     """
-    _styles_iter = (
-        (str(key), val) for key, val in getattr(style, "styles", {}).items()
-    )
+    _styles_iter = ((key, val) for key, val in getattr(style, "styles", {}).items())
     _relevant_styles_iter = filter(lambda tpl: tpl[0] in relevant_styles, _styles_iter)
     return {key: val for key, val in _relevant_styles_iter}

--- a/tests/tabular_output/test_output_formatter.py
+++ b/tests/tabular_output/test_output_formatter.py
@@ -214,13 +214,21 @@ def test_enforce_iterable():
             assert False, "{0} doesn't return iterable".format(format_name)
 
 
-def test_all_text_type():
+@pytest.mark.parametrize(
+    "extra_kwargs",
+    [
+        {},
+        {"style": "default"},
+        {"style": "colorful"},
+    ],
+)
+def test_all_text_type(extra_kwargs):
     """Test the TabularOutputFormatter class."""
     data = [[1, "", None, Decimal(2)]]
     headers = ["col1", "col2", "col3", "col4"]
     output_formatter = TabularOutputFormatter()
     for format_name in output_formatter.supported_formats:
         for row in output_formatter.format_output(
-            iter(data), headers, format_name=format_name, style="default"
+            iter(data), headers, format_name=format_name, **extra_kwargs
         ):
             assert isinstance(row, text_type), "not unicode for {}".format(format_name)

--- a/tests/tabular_output/test_output_formatter.py
+++ b/tests/tabular_output/test_output_formatter.py
@@ -221,6 +221,6 @@ def test_all_text_type():
     output_formatter = TabularOutputFormatter()
     for format_name in output_formatter.supported_formats:
         for row in output_formatter.format_output(
-            iter(data), headers, format_name=format_name
+            iter(data), headers, format_name=format_name, style="default"
         ):
             assert isinstance(row, text_type), "not unicode for {}".format(format_name)

--- a/tests/tabular_output/test_preprocessors.py
+++ b/tests/tabular_output/test_preprocessors.py
@@ -250,9 +250,9 @@ def test_style_output_custom_tokens():
         data,
         headers,
         style=CliStyle,
-        header_token="Token.Results.Headers",
-        odd_row_token="Token.Results.OddRows",
-        even_row_token="Token.Results.EvenRows",
+        header_token=Token.Results.Headers,
+        odd_row_token=Token.Results.OddRows,
+        even_row_token=Token.Results.EvenRows,
     )
 
     assert (expected_data, expected_headers) == (list(output[0]), output[1])


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Fixes https://github.com/dbcli/pgcli/issues/1303
and allows to un-pin `pygments`

I did a quick manual test with pgcli+pygments=2.11.2 and it no longer throws an error, but I would appreciate if someone could re-check.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
