### PR TITLE
Don't backslash-escape newlines, etc. in `ascii` tables, and add `ascii_escaped` table format

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ This project receives help from these awesome contributors:
 - Waldir Pimenta
 - Mel Dafert
 - Andrii Kohut
+- Roland Walker
 
 Thanks
 ------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+TBD
+-------------
+* don't escape newlines, etc. in ascii tables, and add ascii_escaped table format
+
 Version 2.2.1
 -------------
 

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -52,8 +52,24 @@ tabulate._table_formats["ascii"] = tabulate.TableFormat(
     with_header_hide=None,
 )
 
+tabulate._table_formats["ascii_escaped"] = tabulate.TableFormat(
+    lineabove=tabulate.Line("+", "-", "+", "+"),
+    linebelowheader=tabulate.Line("+", "-", "+", "+"),
+    linebetweenrows=None,
+    linebelow=tabulate.Line("+", "-", "+", "+"),
+    headerrow=tabulate.DataRow("|", "|", "|"),
+    datarow=tabulate.DataRow("|", "|", "|"),
+    padding=1,
+    with_header_hide=None,
+)
+
 # "minimal" is the same as "plain", but without headers
 tabulate._table_formats["minimal"] = tabulate._table_formats["plain"]
+
+tabulate.multiline_formats["psql_unicode"] = "psql_unicode"
+tabulate.multiline_formats["double"] = "double"
+tabulate.multiline_formats["ascii"] = "ascii"
+tabulate.multiline_formats["minimal"] = "minimal"
 
 supported_markup_formats = (
     "mediawiki",
@@ -66,6 +82,7 @@ supported_markup_formats = (
 )
 supported_table_formats = (
     "ascii",
+    "ascii_escaped",
     "plain",
     "simple",
     "minimal",
@@ -82,7 +99,10 @@ supported_table_formats = (
 
 supported_formats = supported_markup_formats + supported_table_formats
 
-default_kwargs = {"ascii": {"numalign": "left"}}
+default_kwargs = {
+    "ascii": {"numalign": "left"},
+    "ascii_escaped": {"numalign": "left"},
+}
 headless_formats = ("minimal",)
 
 

--- a/tests/tabular_output/test_output_formatter.py
+++ b/tests/tabular_output/test_output_formatter.py
@@ -23,6 +23,41 @@ def test_tabular_output_formatter():
     ]
     expected = dedent(
         """\
+        +-------+---------+
+        | text  | numeric |
+        +-------+---------+
+        | abc   | 1       |
+        | defg  | 11.1    |
+        | hi    | 1.1     |
+        | Pablo | 0       |
+        | ß     |         |
+        +-------+---------+"""
+    )
+
+    print(expected)
+    print(
+        "\n".join(
+            TabularOutputFormatter().format_output(
+                iter(data), headers, format_name="ascii"
+            )
+        )
+    )
+    assert expected == "\n".join(
+        TabularOutputFormatter().format_output(iter(data), headers, format_name="ascii")
+    )
+
+
+def test_tabular_output_escaped():
+    """Test the ascii_escaped output format."""
+    headers = ["text", "numeric"]
+    data = [
+        ["abc", Decimal(1)],
+        ["defg", Decimal("11.1")],
+        ["hi", Decimal("1.1")],
+        ["Pablo\rß\n", 0],
+    ]
+    expected = dedent(
+        """\
         +------------+---------+
         | text       | numeric |
         +------------+---------+
@@ -37,12 +72,14 @@ def test_tabular_output_formatter():
     print(
         "\n".join(
             TabularOutputFormatter().format_output(
-                iter(data), headers, format_name="ascii"
+                iter(data), headers, format_name="ascii_escaped"
             )
         )
     )
     assert expected == "\n".join(
-        TabularOutputFormatter().format_output(iter(data), headers, format_name="ascii")
+        TabularOutputFormatter().format_output(
+            iter(data), headers, format_name="ascii_escaped"
+        )
     )
 
 


### PR DESCRIPTION
## Description

Don't backslash-escape newlines, etc. in `ascii` tables, and add an `ascii_escaped` table format for users who want that behavior.

After the discussion in https://github.com/dbcli/mycli/issues/1085 , I'm convinced that if `ascii` is the recommended format in `~/.myclirc` then that format shouldn't escape newlines.  Escaping doesn't seem like what the beginning user would want or understand.  The advanced user knows how to change the setting in the config file.

@pasenor this partially reverts #60 so I don't want to go farther without your approval.  An `ascii_escaped` format was added, so it's not a revert in functionality, only defaults.  Other `*_escaped` formats could be added.

Another option would be to add an `ascii_unescaped`, leave `ascii` unchanged, and change the default in the mycli repo.

I'm open to any/all ways forward, but am sympathetic to @doublep in https://github.com/dbcli/mycli/issues/1085, because I agree `SHOW CREATE TABLE` is a more common usecase than the example in #60 .

Familiar defaults which are closer to the stock `mysql` client are also not bad.

## Checklist
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] ~I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code~ the pre-commit hooks seem to be broken so I ran `black` manually
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
