### PR TITLE
Add two JSON-based output formats

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Added noheader CSV and TSV output formats.
+- Added `jsonl` and `jsonl_escaped` output formats.
 
 ## Version 2.4.0
 

--- a/cli_helpers/tabular_output/json_output_adapter.py
+++ b/cli_helpers/tabular_output/json_output_adapter.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""A JSON data output adapter"""
+
+from itertools import chain
+import json
+
+from .preprocessors import bytes_to_string, override_missing_value, convert_to_string
+
+supported_formats = ("jsonl", "jsonl_escaped")
+preprocessors = (override_missing_value, bytes_to_string, convert_to_string)
+
+
+def adapter(data, headers, table_format="jsonl", **_kwargs):
+    """Wrap the formatting inside a function for TabularOutputFormatter."""
+    if table_format == "jsonl":
+        ensure_ascii = False
+    elif table_format == "jsonl_escaped":
+        ensure_ascii = True
+    else:
+        raise ValueError("Invalid table_format specified.")
+
+    for row in chain(data):
+        yield json.dumps(
+            dict(zip(headers, row, strict=True)),
+            separators=(",", ":"),
+            ensure_ascii=ensure_ascii,
+        )

--- a/tests/tabular_output/test_json_output_adapter.py
+++ b/tests/tabular_output/test_json_output_adapter.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Test the json output adapter."""
+
+from __future__ import unicode_literals
+
+from cli_helpers.tabular_output import json_output_adapter
+
+
+def test_jsonl_wrapper():
+    """Test the jsonl output adapter."""
+    # Test jsonl output.
+    data = [["ab\r\nc", 1], ["d", 456]]
+    headers = ["letters", "number"]
+    output = json_output_adapter.adapter(iter(data), headers, table_format="jsonl")
+    assert (
+        "\n".join(output)
+        == """{"letters":"ab\\r\\nc","number":1}\n{"letters":"d","number":456}"""
+    )
+
+
+def test_unicode_with_jsonl():
+    """Test that the jsonl wrapper can pass through non-ascii characters."""
+    data = [["观音", 1], ["Ποσειδῶν", 456]]
+    headers = ["letters", "number"]
+    output = json_output_adapter.adapter(data, headers, table_format="jsonl")
+    assert (
+        "\n".join(output)
+        == """{"letters":"观音","number":1}\n{"letters":"Ποσειδῶν","number":456}"""
+    )
+
+
+def test_unicode_with_jsonl_esc():
+    """Test that the jsonl_escaped wrapper JSON-escapes non-ascii characters."""
+    data = [["观音", 1], ["Ποσειδῶν", 456]]
+    headers = ["letters", "number"]
+    output = json_output_adapter.adapter(data, headers, table_format="jsonl_escaped")
+    assert (
+        "\n".join(output)
+        == """{"letters":"\\u89c2\\u97f3","number":1}\n{"letters":"\\u03a0\\u03bf\\u03c3\\u03b5\\u03b9\\u03b4\\u1ff6\\u03bd","number":456}"""
+    )


### PR DESCRIPTION
## Description

Add two JSON-based output formats

 * `jsonl`: JSONlines format: in which each row is represented on a line as a JSON object, with the column names recapitulated on every line as the property names.
 * `jsonl_escaped`: like `jsonl`, except that JSON escaping is applied for non-ASCII characters.

Most users will want `jsonl`.  The implementation file has the generic name `json_output_adapter.py` in case other JSONish forms are desired.

This output format can be combined with jq redirection in mycli:

 * https://github.com/dbcli/mycli/pull/1248

## Checklist
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
