### PR TITLE
Followups for JSON output formats

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+- Register the JSON formats so they are actually usable.
+- Make JSON formats able to encode Decimals and None/NULLs.
+	
 ## Version 2.5.0
 
 - Added noheader CSV and TSV output formats.

--- a/cli_helpers/tabular_output/output_formatter.py
+++ b/cli_helpers/tabular_output/output_formatter.py
@@ -17,6 +17,7 @@ from . import (
     vertical_table_adapter,
     tabulate_adapter,
     tsv_output_adapter,
+    json_output_adapter,
 )
 from decimal import Decimal
 
@@ -252,4 +253,15 @@ for tsv_format in tsv_output_adapter.supported_formats:
         tsv_output_adapter.adapter,
         tsv_output_adapter.preprocessors,
         {"table_format": tsv_format, "missing_value": "", "max_field_width": None},
+    )
+
+for json_format in json_output_adapter.supported_formats:
+    TabularOutputFormatter.register_new_formatter(
+        json_format,
+        json_output_adapter.adapter,
+        json_output_adapter.preprocessors,
+        {
+            "table_format": json_format,
+            "max_field_width": None,
+        },
     )

--- a/tests/tabular_output/test_json_output_adapter.py
+++ b/tests/tabular_output/test_json_output_adapter.py
@@ -3,6 +3,8 @@
 
 from __future__ import unicode_literals
 
+from decimal import Decimal
+
 from cli_helpers.tabular_output import json_output_adapter
 
 
@@ -26,6 +28,28 @@ def test_unicode_with_jsonl():
     assert (
         "\n".join(output)
         == """{"letters":"观音","number":1}\n{"letters":"Ποσειδῶν","number":456}"""
+    )
+
+
+def test_decimal_with_jsonl():
+    """Test that the jsonl wrapper can pass through Decimal values."""
+    data = [["ab\r\nc", 1], ["d", Decimal(4.56)]]
+    headers = ["letters", "number"]
+    output = json_output_adapter.adapter(iter(data), headers, table_format="jsonl")
+    assert (
+        "\n".join(output)
+        == """{"letters":"ab\\r\\nc","number":1}\n{"letters":"d","number":4.56}"""
+    )
+
+
+def test_null_with_jsonl():
+    """Test that the jsonl wrapper can pass through null values."""
+    data = [["ab\r\nc", None], ["d", None]]
+    headers = ["letters", "value"]
+    output = json_output_adapter.adapter(iter(data), headers, table_format="jsonl")
+    assert (
+        "\n".join(output)
+        == """{"letters":"ab\\r\\nc","value":null}\n{"letters":"d","value":null}"""
     )
 
 

--- a/tests/tabular_output/test_output_formatter.py
+++ b/tests/tabular_output/test_output_formatter.py
@@ -177,6 +177,13 @@ def test_unsupported_format():
         formatter.format_output((), (), format_name="foobar")
 
 
+def test_supported_json_formats():
+    """Test that the JSONl formats are known."""
+    formatter = TabularOutputFormatter()
+    assert "jsonl" in formatter.supported_formats
+    assert "jsonl_escaped" in formatter.supported_formats
+
+
 def test_tabulate_ansi_escape_in_default_value():
     """Test that ANSI escape codes work with tabulate."""
 


### PR DESCRIPTION
## Description
 * formats must be _registered_, or they aren't available for use in client software
 * make JSON formats able to encode Decimal values, emitting floats
 * make JSON formats able to encode None/NULL values, emitting nulls


## Checklist
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
