### PR TITLE
Pin Pygments to v2.19.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,21 +1,28 @@
 # Changelog
 
+## Version 2.13.0
+
+(released on 2026-04-13)
+
+- Pin Pygments library to older version v2.19.2 to fix tests.
+- Fix dates in changelog.
+
 ## Version 2.12.0
 
-(released on 2025-03-21)
+(released on 2026-03-21)
 
 - Probe tabulate version for `preserve_whitespace` keyword support.
 
 ## Version 2.11.0
 
-(released on 2025-03-05)
+(released on 2026-03-05)
 
 - Support and require version 0.10.x of `tabulate`.
 - Pin `tabulate` version more tightly.
 
 ## Version 2.10.1
 
-(released on 2025-02-18)
+(released on 2026-02-18)
 
 - Update license dates.
 - Change `master` branch references to `main`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ autopep8==1.3.3
 codecov==2.1.13
 coverage==4.3.4
 black>=20.8b1
-Pygments>=2.4.0
+Pygments~=2.19.2
 pytest==7.4.3
 pytest-cov==2.4.0
 Sphinx==1.5.5

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "tabulate[widechars] ~= 0.10.0",
     ],
     extras_require={
-        "styles": ["Pygments >= 1.6"],
+        "styles": ["Pygments ~= 2.19.2"],
     },
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
## Description

Pin Pygments to v2.19.2 since v2.20.0, breaks some tests.  The tests are probably fragile, but this is an immediate fix.

Fixes #110.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
