### PR TITLE
Add `mysql_heavy` table format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 2.15.0
+
+(released on 2026-05-16)
+
+- Add `mysql_heavy` table format.
+
 ## Version 2.14.0
 
 (released on 2026-04-13)

--- a/cli_helpers/tabular_output/tabulate_adapter.py
+++ b/cli_helpers/tabular_output/tabulate_adapter.py
@@ -92,6 +92,17 @@ tabulate._table_formats["mysql_unicode"] = tabulate.TableFormat(
     with_header_hide=None,
 )
 
+tabulate._table_formats["mysql_heavy"] = tabulate.TableFormat(
+    lineabove=tabulate.Line("┏", "━", "┳", "┓"),
+    linebelowheader=tabulate.Line("┣", "━", "╋", "┫"),
+    linebetweenrows=None,
+    linebelow=tabulate.Line("┗", "━", "┻", "┛"),
+    headerrow=tabulate.DataRow("┃", "┃", "┃"),
+    datarow=tabulate.DataRow("┃", "┃", "┃"),
+    padding=1,
+    with_header_hide=None,
+)
+
 # "minimal" is the same as "plain", but without headers
 tabulate._table_formats["minimal"] = tabulate._table_formats["plain"]
 
@@ -128,6 +139,7 @@ supported_table_formats = (
     "double",
     "mysql",
     "mysql_unicode",
+    "mysql_heavy",
 )
 
 supported_formats = supported_markup_formats + supported_table_formats


### PR DESCRIPTION
## Description
Like `mysql_unicode`, but with heavy Unicode lines.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
